### PR TITLE
MWPW-123753 Review component spacing is being held when viewing the conversion complete screen

### DIFF
--- a/acrobat/blocks/personalization/personalization.js
+++ b/acrobat/blocks/personalization/personalization.js
@@ -90,6 +90,7 @@ export default function init(element) {
         ele.dataset.tag = ele.firstElementChild.textContent;
         defaultContent('live', showAll);
         reviewBlock.forEach((reviewEle) => {
+          reviewEle.parentElement.classList.remove("xxl-spacing");
           reviewEle.classList.add('hide');
         });
 


### PR DESCRIPTION
Before:  https://main--acrobat--adobecom.hlx.page/acrobat/online/pdf-to-ppt
After:  https://mwpw-123753--acrobat--adobecom.hlx.page/acrobat/online/pdf-to-ppt

To test: See step by step description in https://jira.corp.adobe.com/browse/MWPW-123753