### PR TITLE
use DOMParser instead of innerHTML

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -48,7 +48,11 @@ export default function init(element) {
       case 200:
         // eslint-disable-next-line no-case-declarations
         const template = await response.text();
-        fakeWidgetContainer.innerHTML = template;
+        // eslint-disable-next-line no-case-declarations
+        const doc = new DOMParser().parseFromString(template, 'text/html');
+        document.head.appendChild(doc.head.getElementsByTagName('Style')[0]);
+        fakeWidgetContainer.appendChild(doc.body.firstElementChild);
+        performance.mark("milo-insert-snippet");
         break;
       case 404:
         break;


### PR DESCRIPTION
The pre-rendered document we are fetching is actually an HTML document with both a Style tag and a div with the content.  In order for React hydration to work, the DOM needs to match what is ultimately rendered, which means just the div part needs to be added to the widgetContainer.  We can put the Style tag directly in the head.

@Blainegunn