### PR TITLE
MWPW-125150 cleanup CSS for browser extension modal

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
@@ -56,22 +56,6 @@ min-height: 560px;
   }
 }
 
-/* Browser Extension */
-.browser-extension {
-  min-width: 480px;
-  padding: 20px;
-}
-
-.browser-extension .col.col-1 {
-  border-right:  1px grey solid;
-}
-
-.col.col-2 picture {
-  width: 90px;
-  height: 90px;
-  margin: auto;
-}
-
 .dialog-modal.extension-modal {
   top: unset;
   right: unset;

--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -215,38 +215,38 @@ div.how-to ol li::before{
   overflow: hidden;
   box-shadow: 0 0.5em 1em -0.125em hsl(0deg 0% 4% / 10%), 0 0 0 1px hsl(0deg 0% 4% / 2%);
 }
-#extension-modal .fragment .section .columns.browser-extension {
+.section .columns.browser-extension {
   padding: 20px;
   font-size: 16px;
   animation-name: modalSlideIn-frictionlessBrowserExtension;
   transition: opacity 125ms ease-in-out,background-color 125ms ease-in-out,backdrop-filter 125ms ease-in-out,-webkit-backdrop-filter 125ms ease-in-out,transform 125ms ease-in-out;
   animation-duration: 2s;
 }
-#extension-modal .fragment .section .columns.browser-extension p {
+.section .columns.browser-extension p {
   margin-top: 0;
   margin-right: 20px;
 }
-#extension-modal .fragment .section .columns.browser-extension > .row {
+.section .columns.browser-extension > .row {
   display: flex;
   margin-bottom: 0;
   gap: 0px;
 }
-#extension-modal .fragment .section .columns.browser-extension picture {
+.section .columns.browser-extension picture {
   width: initial;
   vertical-align: middle;
   display: flex;
   padding: 20px 10px 0px 10px;
 }
-#extension-modal .fragment .section .columns.browser-extension picture img {
+.section .columns.browser-extension picture img {
   width: 100%;
   max-width: 150px;
   padding: 10px;
   display: block;
 }
-#extension-modal .fragment .section .columns.browser-extension .row .col-1 {
+.section .columns.browser-extension .row .col-1 {
   width: 70%;
 }
-#extension-modal .fragment .section .columns.browser-extension .row .col-1 a {
+.section .columns.browser-extension .row .col-1 a {
   border-width: 2px;
   border-style: solid;
   border-radius: 16px;
@@ -260,12 +260,13 @@ div.how-to ol li::before{
   border-color: #505050;
   color: #505050;
 }
-#extension-modal .fragment .section .columns.browser-extension .row .col-1 a:hover {
+.section .columns.browser-extension .row .col-1 a:hover {
   background-color: #505050;
   color: #ffffff;
   text-decoration: none;
 }
-#extension-modal .fragment .section .columns.browser-extension .row .col-2 {
+
+.section .columns.browser-extension .row .col-2 {
   width: 30%;
   border-left: solid 2px #EAEAEA;
 }


### PR DESCRIPTION
There was some missmatch in CSS for the browser extension modal dialog, e.g. the button would appear as a link , see orginal issue : https://jira.corp.adobe.com/browse/MWPW-125150

Before: https://main--dc--adobecom.hlx.page/dc-shared/fragments/shared-fragments/browser-extension/browser-extension-edge
https://main--dc--adobecom.hlx.page/dc-shared/fragments/shared-fragments/browser-extension/browser-extension-chrome
After: https://mwpw-125150--dc--adobecom.hlx.page/dc-shared/fragments/shared-fragments/browser-extension/browser-extension-edge
https://mwpw-125150--dc--adobecom.hlx.page/dc-shared/fragments/shared-fragments/browser-extension/browser-extension-chrome