### PR TITLE
MWPW-123750 fix salmon background

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
@@ -14,6 +14,7 @@ min-height: 560px;
   position: relative;
   overflow: hidden;
   left:0;
+  top: 30px;
   right:0;
 }
 

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
@@ -14,7 +14,7 @@ min-height: 560px;
   position: relative;
   overflow: hidden;
   left:0;
-  top: 30px;
+  top: 70px;
   right:0;
 }
 

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
@@ -2,6 +2,7 @@
 background-color: #fc6767;
 min-height: 560px;
 }
+
 .dc-wrapper {
   /* width: 100%;
   max-width: 1100px; */
@@ -11,7 +12,9 @@ min-height: 560px;
   margin: auto;
   padding: 0 0 0 ;
   position: relative;
-  top: 60px;
+  overflow: hidden;
+  left:0;
+  right:0;
 }
 
 .dc-wrapper .react-spectrum-provider {
@@ -21,16 +24,6 @@ min-height: 560px;
 
 #VERB, .hide {
   display: none;
-}
-
-.dc-wrapper {
-  overflow: hidden;
-  top: 70px;
-  left:0;
-  right:0;
-  margin-left:auto;
-  margin-right:auto;
-  position: absolute;
 }
 
 /* fake widget */


### PR DESCRIPTION
See https://jira.corp.adobe.com/browse/MWPW-123750
Fixed salom background to always be large enough in desktop, tablet, mobile view so that the widget does not overlap the  text that comes afterwards:

Before: https://main--dc--adobecom.hlx.page/acrobat/online/pdf-to-ppt
After: https://mwpw-123750--dc--adobecom.hlx.page/acrobat/online/pdf-to-ppt
