### PR TITLE
remove dublicate .dc-wrapper CSS

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.css
@@ -4,8 +4,6 @@
 }
 
 .dc-wrapper {
-  /* width: 100%;
-  max-width: 1100px; */
   width: 75%;
   max-width: 75%;
   height: auto;
@@ -16,25 +14,11 @@
   left:0;
   top: 70px;
   right:0;
+  z-index: 1;
 }
 
 #VERB, .hide {
   display: none;
-}
-
-
-.dc-wrapper {
-  overflow: hidden;
-  width: 75%;
-  max-width: 75%;
-  margin: auto;
-  top: 70px;
-  left:0;
-  right:0;
-  margin-left:auto;
-  margin-right:auto;
-  position: relative;
-  z-index: 1;
 }
 
 @media (max-width: 37.5rem) {


### PR DESCRIPTION
merging `main` branch into this [PR ](https://github.com/adobecom/dc/pull/102) somehow brought back the dublicate `.dc-wrapper `entry:

![image](https://user-images.githubusercontent.com/37147400/216123837-671341bf-efa0-431a-a45a-3edb83b884dc.png)

Before: https://main--dc--adobecom.hlx.page/acrobat/online/pdf-to-ppt
After: https://mwpw-123750-2--dc--adobecom.hlx.page/acrobat/online/pdf-to-ppt

there should be no difference before and after:
- upload a file 
- use browser console device toggle to resize window
-  the widget should still not overlap the text that comes after.