### PR TITLE
CSP requires single quotes for keywords

### DIFF
--- a/acrobat/scripts/contentSecurityPolicy/prod.js
+++ b/acrobat/scripts/contentSecurityPolicy/prod.js
@@ -1,5 +1,5 @@
 const connectSrc = [
-  '"self"',
+  '\'self\'',
   'blob:',
   '14257-chimera.adobeioruntime.net',
   '*.adobe.com',
@@ -35,7 +35,7 @@ const connectSrc = [
 ];
 
 const defaultSrc = [
-  '"self"',
+  '\'self\'',
   'acrobat.adobe.com',
   'auth.services.adobe.com',
   'documentcloud.adobe.com',
@@ -43,7 +43,7 @@ const defaultSrc = [
 ];
 
 const fontSrc = [
-  '"self"',
+  '\'self\'',
   'use.typekit.net',
   ';',
 ];
@@ -58,7 +58,7 @@ const formAction = [
 ];
 
 const frameSrc = [
-  '"self"',
+  '\'self\'',
   'data:',
   'blob:',
   '*.amazonaws.com',
@@ -82,7 +82,7 @@ const frameSrc = [
 ];
 
 const imgSrc = [
-  '"self"',
+  '\'self\'',
   'about:',
   'blob:',
   'data:',
@@ -123,13 +123,13 @@ const imgSrc = [
 ];
 
 const manifestSrc = [
-  '"self"',
+  '\'self\'',
   ';',
 ];
 
 const scriptSrc = [
-  '"self"',
-  '"unsafe-eval"',
+  '\'self\'',
+  '\'unsafe-eval\'',
   '*.adobe.com',
   '*.clarity.ms',
   'accounts.google.com/gsi/client',
@@ -190,8 +190,8 @@ const scriptSrc = [
 ];
 
 const styleSrc = [
-  '"self"',
-  '"unsafe-inline"',
+  '\'self\'',
+  '\'unsafe-inline\'',
   '*.adobe.com',
   'accounts.google.com/gsi/style',
   'adobeccstatic.com',
@@ -200,20 +200,20 @@ const styleSrc = [
 ];
 
 const workerSrc = [
-  '"self"',
-  'blob:"',
-  'cdnssl.clicktale.net"',
-  'www.adobe.com/"',
+  '\'self\'',
+  'blob:',
+  'cdnssl.clicktale.net',
+  'www.adobe.com/',
   ';',
 ];
 
 const reportUri = [
-  '"https://dc-api.adobe.io/system/csp"',
+  '\'https://dc-api.adobe.io/system/csp\'',
   ';',
 ];
 
 const reportTo = [
-  '"default"',
+  '\'default\'',
   ';',
 ];
 

--- a/acrobat/scripts/contentSecurityPolicy/stage.js
+++ b/acrobat/scripts/contentSecurityPolicy/stage.js
@@ -1,5 +1,5 @@
 const connectSrc = [
-  '"self"',
+  '\'self\'',
   'blob:',
   '14257-chimera-stage.adobeioruntime.net',
   '*.adobe.com',
@@ -40,7 +40,7 @@ const connectSrc = [
 ];
 
 const defaultSrc = [
-  '"self"',
+  '\'self\'',
   'auth-stg1.services.adobe.com',
   'dc.stage.acrobat.com',
   'stage.acrobat.adobe.com',
@@ -48,7 +48,7 @@ const defaultSrc = [
 ];
 
 const fontSrc = [
-  '"self"',
+  '\'self\'',
   'use.typekit.net',
   ';',
 ];
@@ -65,7 +65,7 @@ const formAction = [
 ];
 
 const frameSrc = [
-  '"self"',
+  '\'self\'',
   'data:',
   'blob:',
   '*.amazonaws.com',
@@ -89,7 +89,7 @@ const frameSrc = [
 ];
 
 const imgSrc = [
-  '"self"',
+  '\'self\'',
   'about:',
   'blob:',
   'data:',
@@ -129,13 +129,13 @@ const imgSrc = [
 ];
 
 const manifestSrc = [
-  '"self"',
+  '\'self\'',
   ';',
 ];
 
 const scriptSrc = [
-  '"self"',
-  '"unsafe-eval"',
+  '\'self\'',
+  '\'unsafe-eval\'',
   '*.adobe.com',
   '*.clarity.ms',
   'accounts.google.com/gsi/client',
@@ -203,8 +203,8 @@ const scriptSrc = [
 ];
 
 const styleSrc = [
-  '"self"',
-  '"unsafe-inline"',
+  '\'self\'',
+  '\'unsafe-inline\'',
   '*.adobe.com',
   'accounts.google.com/gsi/style',
   'dc.stage.acrobat.com',
@@ -214,7 +214,7 @@ const styleSrc = [
 ];
 
 const workerSrc = [
-  '"self"',
+  '\'self\'',
   'blob:',
   'cdnssl.clicktale.net',
   ';',


### PR DESCRIPTION
The CSP files for stage and prod are not using single quotes for keywords like 'self', 'unsafe-eval'.
See : https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources

Before; https://main--dc--adobecom.hlx.page/acrobat/online/pdf-to-ppt
After: https://csp-use-single-quotes--dc--adobecom.hlx.page/acrobat/online/pdf-to-ppt

NOTE: the above cant be compared since main used prod CSP and the branch uses dev CSP