### PR TITLE
added github action to run nala tests on PRs

### DIFF
--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -1,0 +1,22 @@
+name: Nala Tests
+
+on:
+  pull_request:
+    types: [ labeled, opened, synchronize, reopened ]
+
+jobs:
+  action:
+    name: Running E2E & IT
+    if: contains(github.event.pull_request.labels.*.name, 'run-nala')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Run Nala
+        uses: adobecom/nala@main # Change if doing dev work
+        env:
+          labels: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+          branch: ${{ github.event.pull_request.head.ref }}
+          IMS_EMAIL: ${{ secrets.IMS_EMAIL }}
+          IMS_PASS: ${{ secrets.IMS_PASS }}


### PR DESCRIPTION
added github action to run nala tests on PRs

To fully make this work desired labels for filtering tests will need to be made on the repository using Nala, i.e., '@converter'

Also, another label named 'run-nala' will need to be added to the repository so developers can add it to their PRs for the nala tests to execute.

Second to help stop a lot of failures if by accident a developer doesn't select a filter label in addition to the 'run-nala' label to GitHub Secrets will need to be added for the IMSLogin Test.