### PR TITLE
MWPW-125486 Set explicit color for Accordion button to black

### DIFF
--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -338,3 +338,7 @@ div.how-to ol li::before{
   top: 0;
   left: 4px;
 }
+
+.accordion dt button {
+  color: #000;
+}


### PR DESCRIPTION
Font in FAQ section colored in blue instead of black. The issue is seen on both mobile & iPad devices.
Looks like some weird apple specific behavior on their devices, see e.g. https://developer.apple.com/forums/thread/690529.
Setting the color explicity solves the issue:

IPad

![ipad](https://user-images.githubusercontent.com/37147400/218503570-a74794d9-8b1f-44bf-b264-ca542a1cc43f.png )


IPhone

![iphone](https://user-images.githubusercontent.com/37147400/218503610-42070123-1ed6-496f-9f29-eff752af04e3.png)

Before: https://main--dc--adobecom.hlx.page/drafts/msagolj/live-test-pdf-to-ppt
After: https://mwpw-125486--dc--adobecom.hlx.page/drafts/msagolj/live-test-pdf-to-ppt
NOTE:
To Test you have to use a real apple device or one from saucelabs: https://app.saucelabs.com/live/web-testing/device