### PR TITLE
GitHub Actions new variable for PR testing with Nala

### DIFF
--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -18,5 +18,6 @@ jobs:
         env:
           labels: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
           branch: ${{ github.event.pull_request.head.ref }}
+          repoName: ${{ github.repository }}
           IMS_EMAIL: ${{ secrets.IMS_EMAIL }}
           IMS_PASS: ${{ secrets.IMS_PASS }}


### PR DESCRIPTION
Added repo name variable so we can distinguish which site's repo Nala is running against for PRs.

This additional variable will send it the particular repository name which will be pulled out in order to set up the URLs correctly for feature branches on consumer sites running Nala against their own repositories.

Resolves: [MWPW-125473](https://jira.corp.adobe.com/browse/MWPW-125473)

Related Nala PR that will use this change for the Frictionless Team/DC Site: https://github.com/adobecom/nala/pull/61

Related Milo PR: https://github.com/adobecom/milo/pull/475