### PR TITLE
Mwpw 125812 update

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -2,7 +2,22 @@ import frictionless from '../../scripts/frictionless.js';
 import { redirectLegacyBrowsers } from '../../scripts/legacyBrowser.js';
 
 const pageLang = document.querySelector('html').lang;
-
+const verbToRedirectLink =  {
+  'createpdf': 'acrobat-createpdf',
+  'crop-pages': 'acrobat-crop',
+  'delete-pages': 'acrobat-deletepages',
+  'extract-pages': 'acrobat-extract',
+  'combine-pdf': 'acrobat-combine',
+  'protect-pdf': 'acrobat-protect',
+  'add-comment': 'acrobat-addcomment',
+  'pdf-to-image': 'acrobat-pdftoimage',
+  'reorder-pages': 'acrobat-reorderpages',
+  'sendforsignature': 'acrobat-sendforsignature',
+  'rotate-pages': 'acrobat-rotatepages',
+  'fillsign': 'acrobat-fillsign',
+  'split-pdf': 'acrobat-split',
+  'insert-pdf': 'acrobat-insert',
+};
 export default function init(element) {
   const widget = element;
   let WIDGET_ENV = 'https://dev.acrobat.adobe.com/dc-hosted/2.37.2_1.165.0/dc-app-launcher.js';
@@ -47,9 +62,9 @@ export default function init(element) {
     if (window.adobeIMS.isSignedInUser()) {
       if (window.location.hostname != 'main--dc--adobecom.hlx.live'
         && window.location.hostname != 'www.adobe.com' ) {
-        window.location = `https://www.adobe.com/go/acrobat-${VERB.split('-').join('')}-${ENV}`|| REDIRECT_URL;
+        window.location = `https://www.adobe.com/go/acrobat-${verbToRedirectLink[VERB]}-${ENV}`|| REDIRECT_URL;
       } else {
-        window.location = REDIRECT_URL || `https://www.adobe.com/go/acrobat-${VERB.split('-').join('')}` || fallBack;
+        window.location = REDIRECT_URL || `https://www.adobe.com/go/acrobat-${verbToRedirectLink[VERB]}` || fallBack;
       }
     }
   };
@@ -64,7 +79,7 @@ export default function init(element) {
   if (preRender) {
     (async () => {
       // TODO: Make dynamic
-      const response = await fetch(DC_GENERATE_CACHE_URL || `https://documentcloud.adobe.com/dc-generate-cache/dc-hosted-1.163.1/${VERB}-${pageLang.toLocaleLowerCase()}.html`);
+      const response = await fetch(DC_GENERATE_CACHE_URL || `https://documentcloud.adobe.com/dc-generate-cache/dc-hosted-1.165.0/${VERB}-${pageLang.toLocaleLowerCase()}.html`);
       // eslint-disable-next-line default-case
       switch (response.status) {
         case 200:

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -2,21 +2,21 @@ import frictionless from '../../scripts/frictionless.js';
 import { redirectLegacyBrowsers } from '../../scripts/legacyBrowser.js';
 
 const pageLang = document.querySelector('html').lang;
-const verbToRedirectLink =  {
-  'createpdf': 'acrobat-createpdf',
-  'crop-pages': 'acrobat-crop',
-  'delete-pages': 'acrobat-deletepages',
-  'extract-pages': 'acrobat-extract',
-  'combine-pdf': 'acrobat-combine',
-  'protect-pdf': 'acrobat-protect',
-  'add-comment': 'acrobat-addcomment',
-  'pdf-to-image': 'acrobat-pdftoimage',
-  'reorder-pages': 'acrobat-reorderpages',
-  'sendforsignature': 'acrobat-sendforsignature',
-  'rotate-pages': 'acrobat-rotatepages',
-  'fillsign': 'acrobat-fillsign',
-  'split-pdf': 'acrobat-split',
-  'insert-pdf': 'acrobat-insert',
+const verbToRedirectLinkSuffix =  {
+  'createpdf': 'createpdf',
+  'crop-pages': 'crop',
+  'delete-pages': 'deletepages',
+  'extract-pages': 'extract',
+  'combine-pdf': 'combine',
+  'protect-pdf': 'protect',
+  'add-comment': 'addcomment',
+  'pdf-to-image': 'pdftoimage',
+  'reorder-pages': 'reorderpages',
+  'sendforsignature': 'sendforsignature',
+  'rotate-pages': 'rotatepages',
+  'fillsign': 'fillsign',
+  'split-pdf': 'split',
+  'insert-pdf': 'insert',
 };
 export default function init(element) {
   const widget = element;
@@ -57,14 +57,15 @@ export default function init(element) {
   }
 
   // Redirect
+  console.log('dinamic', `https://www.adobe.com/go/acrobat-${verbToRedirectLinkSuffix[VERB] || VERB.split('-').join('')}-${ENV}`);
   const fallBack = 'https://www.adobe.com/go/acrobat-overview';
   const redDir = () => {
     if (window.adobeIMS.isSignedInUser()) {
       if (window.location.hostname != 'main--dc--adobecom.hlx.live'
         && window.location.hostname != 'www.adobe.com' ) {
-        window.location = `https://www.adobe.com/go/acrobat-${verbToRedirectLink[VERB] || VERB.split('-').join('')}-${ENV}`|| REDIRECT_URL;
+        window.location = `https://www.adobe.com/go/acrobat-${verbToRedirectLinkSuffix[VERB] || VERB.split('-').join('')}-${ENV}`|| REDIRECT_URL;
       } else {
-        window.location = REDIRECT_URL || `https://www.adobe.com/go/acrobat-${verbToRedirectLink[VERB] || VERB.split('-').join('')}` || fallBack;
+        window.location = REDIRECT_URL || `https://www.adobe.com/go/acrobat-${verbToRedirectLinkSuffix[VERB] || VERB.split('-').join('')}` || fallBack;
       }
     }
   };

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -58,13 +58,16 @@ export default function init(element) {
 
   // Redirect
   const fallBack = 'https://www.adobe.com/go/acrobat-overview';
+  console.log('verb', verbToRedirectLink[VERB]);
+  console.log('verb2', VERB.split('-').join(''));
+  console.log('verb3', verbToRedirectLink[VERB] || VERB.split('-').join(''));
   const redDir = () => {
     if (window.adobeIMS.isSignedInUser()) {
       if (window.location.hostname != 'main--dc--adobecom.hlx.live'
         && window.location.hostname != 'www.adobe.com' ) {
-        window.location = `https://www.adobe.com/go/acrobat-${verbToRedirectLink[VERB]}-${ENV}`|| REDIRECT_URL;
+        window.location = `https://www.adobe.com/go/acrobat-${verbToRedirectLink[VERB] || VERB.split('-').join('')}-${ENV}`|| REDIRECT_URL;
       } else {
-        window.location = REDIRECT_URL || `https://www.adobe.com/go/acrobat-${verbToRedirectLink[VERB]}` || fallBack;
+        window.location = REDIRECT_URL || `https://www.adobe.com/go/acrobat-${verbToRedirectLink[VERB] || VERB.split('-').join('')}` || fallBack;
       }
     }
   };

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -58,9 +58,6 @@ export default function init(element) {
 
   // Redirect
   const fallBack = 'https://www.adobe.com/go/acrobat-overview';
-  console.log('verb', verbToRedirectLink[VERB]);
-  console.log('verb2', VERB.split('-').join(''));
-  console.log('verb3', verbToRedirectLink[VERB] || VERB.split('-').join(''));
   const redDir = () => {
     if (window.adobeIMS.isSignedInUser()) {
       if (window.location.hostname != 'main--dc--adobecom.hlx.live'


### PR DESCRIPTION
Updates version for generate-cache to  correct version (1.163.1 vs 1.165.0) - per @JFernandezAdobe request on the ticket.

Added mappings for dynamically generated redirect urls (since for some verbs they are not following pattern and VERB.split('-').join('') would not give correct result, for example: for verb crop-pages, redirect url should be https://www.adobe.com/go/acrobat-crop and not https://www.adobe.com/go/acrobat-croppages, as for verbs extract-pages,combine-pdf,protect-pdf