### PR TITLE
MWPW-127980: Added css for reading-width

### DIFF
--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -381,3 +381,9 @@ div.how-to ol li::before{
 .accordion dt button {
   color: #000;
 }
+
+.reading-width {
+  max-width: 600px;
+  margin: auto;
+  padding: 20px;
+}


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-127980

Before: https://main--dc--adobecom.hlx.page/acrobat/hub/how-to/10-benefits-of-digitizing-documents
After: https://mwpw-127980-add-missing-css-to-short-pages--dc--adobecom.hlx.page/acrobat/hub/how-to/10-benefits-of-digitizing-documents