### PR TITLE
MWPW-128105 - stage.adobe.com + MILO libs

### DIFF
--- a/acrobat/scripts/utils.js
+++ b/acrobat/scripts/utils.js
@@ -23,23 +23,17 @@ export const [setLibs, getLibs] = (() => {
   let libs;
   return [
     (prodLibs) => {
-      const { hostname } = window.location;
-      const stageEnvs = ['localhost', 'hlx.page', 'hlx.live', 'stage.adobe.com'];
-      if (!stageEnvs.some((env) => hostname.includes(env))) {
-        libs = prodLibs;
-      } else {
-        const env = hostname === "www.stage.adobe.com" ? 'stage' : 'main';
-        const branch = new URLSearchParams(window.location.search).get('milolibs') || env;
-        if (branch === 'local') {
-          libs = 'http://localhost:6456/libs';
-        } else if (branch.indexOf('--') > -1) {
-          libs = `https://${branch}.hlx.page/libs`;
-        } else if (branch === 'stage') {
-          libs = 'https://www.adobe.com/libs';
-        } else {
-          libs = `https://${branch}--milo--adobecom.hlx.page/libs`;
+      libs = (() => {
+        const { hostname } = window.location;
+        const stageEnvs = ['localhost', 'hlx.page', 'hlx.live', 'stage.adobe.com'];
+        if (!stageEnvs.some((env) => hostname.includes(env))) {
+          return prodLibs;
         }
-      }
+        const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
+        if (branch === 'local') return 'http://localhost:6456/libs';
+        if (branch === 'main' && hostname === "www.stage.adobe.com") return 'https://www.adobe.com/libs';
+        return branch.includes('--') ? `https://${branch}.hlx.page/libs` : `https://${branch}--milo--adobecom.hlx.page/libs`;
+      })();
       return libs;
     }, () => libs,
   ];

--- a/acrobat/scripts/utils.js
+++ b/acrobat/scripts/utils.js
@@ -22,16 +22,13 @@
 export const [setLibs, getLibs] = (() => {
   let libs;
   return [
-    (prodLibs) => {
+    (prodLibs, location) => {
       libs = (() => {
-        const { hostname } = window.location;
-        const stageEnvs = ['localhost', 'hlx.page', 'hlx.live', 'stage.adobe.com'];
-        if (!stageEnvs.some((env) => hostname.includes(env))) {
-          return prodLibs;
-        }
-        const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
+        const { hostname, search } = location || window.location;
+        const branch = new URLSearchParams(search).get('milolibs') || 'main';
+        if (branch === 'main' && hostname === 'www.stage.adobe.com') return 'https://www.adobe.com/libs';
+        if (!(hostname.includes('.hlx.') || hostname.includes('local') || hostname.includes('stage'))) return prodLibs;
         if (branch === 'local') return 'http://localhost:6456/libs';
-        if (branch === 'main' && hostname === "www.stage.adobe.com") return 'https://www.adobe.com/libs';
         return branch.includes('--') ? `https://${branch}.hlx.page/libs` : `https://${branch}--milo--adobecom.hlx.page/libs`;
       })();
       return libs;

--- a/acrobat/scripts/utils.js
+++ b/acrobat/scripts/utils.js
@@ -27,14 +27,20 @@ export const [setLibs, getLibs] = (() => {
       const stageEnvs = ['localhost', 'hlx.page', 'hlx.live', 'stage.adobe.com'];
       if (!stageEnvs.some((env) => hostname.includes(env))) {
         libs = prodLibs;
-        return libs;
+      } else {
+        const env = hostname === "www.stage.adobe.com" ? 'stage' : 'main';
+        const branch = new URLSearchParams(window.location.search).get('milolibs') || env;
+        if (branch === 'local') {
+          libs = 'http://localhost:6456/libs';
+        } else if (branch.indexOf('--') > -1) {
+          libs = `https://${branch}.hlx.page/libs`;
+        } else if (branch === 'stage') {
+          libs = 'https://www.adobe.com/libs';
+        } else {
+          libs = `https://${branch}--milo--adobecom.hlx.page/libs`;
+        }
       }
-      let env = hostname === "www.stage.adobe.com" ? 'stage' : 'main';
-      const branch = new URLSearchParams(window.location.search).get('milolibs') || env;
-      if (branch === 'local') return 'http://localhost:6456/libs';
-      if (branch.indexOf('--') > -1) return `https://${branch}.hlx.page/libs`;
-      if (branch === 'stage') return 'https://www.adobe.com/libs';
-      return `https://${branch}--milo--adobecom.hlx.page/libs`;
+      return libs;
     }, () => libs,
   ];
 })();

--- a/acrobat/scripts/utils.js
+++ b/acrobat/scripts/utils.js
@@ -29,9 +29,11 @@ export const [setLibs, getLibs] = (() => {
         libs = prodLibs;
         return libs;
       }
-      const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
+      let env = hostname === "www.stage.adobe.com" ? 'stage' : 'main';
+      const branch = new URLSearchParams(window.location.search).get('milolibs') || env;
       if (branch === 'local') return 'http://localhost:6456/libs';
       if (branch.indexOf('--') > -1) return `https://${branch}.hlx.page/libs`;
+      if (branch === 'stage') return 'https://www.adobe.com/libs';
       return `https://${branch}--milo--adobecom.hlx.page/libs`;
     }, () => libs,
   ];


### PR DESCRIPTION
Resolve: https://jira.corp.adobe.com/browse/MWPW-128105

According from the @JFernandezAdobe requirement, files which were coming from _main-milo-adobecom.hlx.page_ before, now are coming from  _www.adobe.com_. 
With this change, www.stage.adobe.com will use production code (www.adobe.com), but with _?milolibs_ param it can be set to use _main--milo--adobecom.hlx.page/libs_ or _localhost/libs_.

I put the label 'do not merge' because I need confirmation that libs should come from _www.adobe.com_ and not from _http://www.stage.adobe.com_

Test URLs (test once the changes are published):
- https://www.stage.adobe.com/acrobat/online/jpg-to-pdf.html
- https://www.stage.adobe.com/acrobat/online/jpg-to-pdf.html?milolibs=local (milo should be run locally)
- https://www.stage.adobe.com/acrobat/online/jpg-to-pdf.html?milolibs=mwpw-125487-header-font-size-howto--milo--draganatrajkovic
- https://www.stage.adobe.com/acrobat/online/jpg-to-pdf.html?milolibs=share-block-updates
- https://www.adobe.com/acrobat/online/pdf-to-ppt.html

