### PR TITLE
MWPW-128729 trigger inside tests

### DIFF
--- a/.github/workflows/run-inside.yml
+++ b/.github/workflows/run-inside.yml
@@ -1,0 +1,23 @@
+name: Inside Tests
+on: [push, pull_request]
+jobs:
+  trigger-circleci:
+    name: Trigger CircleCI Job
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - name: Trigger CircleCI Job
+        run: |
+          curl -X POST 'https://circle.ci.adobe.com/api/v2/project/gh/wcms/Platform-UI-DC/pipeline' \
+              -H 'Circle-Token: ${{ secrets.CCI_TOKEN }}' \
+              -H 'content-type: application/json' \
+              -d "{\"branch\":\"main\", \
+                    \"parameters\":{ \
+                      \"env\":\"live\", \
+                      \"dcbranch\":\"${{ github.head_ref || github.ref_name }}\" \
+                    } \
+              }"
+
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST 'https://dc.ci.corp.adobe.com/job/DC%20Release%20-%20Run%20Nala/buildWithParameters?token=${{ secrets.JNK_JOB_TOKEN }}&branch=${{ github.head_ref || github.ref_name }}' \
+              -u '${{ secrets.JNK_USER }}:${{ secrets.JNK_API_TOKEN }}'

--- a/.github/workflows/run-inside.yml
+++ b/.github/workflows/run-inside.yml
@@ -1,5 +1,12 @@
 name: Inside Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - stage
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - stage
 jobs:
   trigger-circleci:
     name: Trigger CircleCI Job


### PR DESCRIPTION
* POC that GitHub Actions can trigger inside tests on the corp CircleCI and Jenkins.
* The trigger events are the same as the unit test's.
* CCI_TOKEN, JNK_USER, JNK_API_TOKEN, and JNK_JOB_TOKEN should be set in the repo's GitHub Actions secrets.