### PR TITLE
Improved handling promotion block from metadata (for FedPub)

### DIFF
--- a/acrobat/blocks/promotion/promotion.js
+++ b/acrobat/blocks/promotion/promotion.js
@@ -1,5 +1,3 @@
-import { getLibs } from '../../scripts/utils.js';
-
 export default async function init(el) {
   const locale = 'en-US';
   const promotionName = el.getAttribute('data-promotion');

--- a/acrobat/blocks/promotion/promotion.js
+++ b/acrobat/blocks/promotion/promotion.js
@@ -1,3 +1,5 @@
+import { getLibs } from '../../scripts/utils.js';
+
 export default async function init(el) {
   const locale = 'en-US';
   const promotionName = el.getAttribute('data-promotion');
@@ -15,3 +17,12 @@ export default async function init(el) {
   el.appendChild(document.createRange()
     .createContextualFragment(promotionContent));
 }
+
+// Solution for FedPub promotions
+export const promotionFromMetadata = async (metadata) => {
+  const promo = document.createElement('div');
+  promo.classList.add('promotion');
+  promo.setAttribute('data-promotion', metadata.toLowerCase());
+  document.querySelector('main > div').appendChild(promo);
+  init(promo);
+};

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -143,23 +143,6 @@ const CONFIG = {
   lcpImg?.setAttribute('loading', 'eager');
 }());
 
-// Temp solution for FedPub promotions
-function decoratePromotion() {
-  if (document.querySelector('main .promotion') instanceof HTMLElement) {
-    return;
-  }
-
-  const promotionElement = document.querySelector('head meta[name="promotion"]');
-  if (!promotionElement) {
-    return;
-  }
-
-  const promo = document.createElement('div');
-  promo.classList.add('promotion');
-  promo.setAttribute('data-promotion', promotionElement.getAttribute('content').toLowerCase());
-  document.querySelector('main > div').appendChild(promo);
-}
-
 /*
  * ------------------------------------------------------------
  * Edit below at your own risk
@@ -193,11 +176,20 @@ function decoratePromotion() {
   loadStyles(paths);
 
   // Import base milo features and run them
-  const { loadArea, loadDelayed, loadScript, setConfig, loadLana } = await import(`${miloLibs}/utils/utils.js`);
-  decoratePromotion();
+  const {
+    loadArea, loadDelayed, loadScript, setConfig, loadLana, getMetadata,
+  } = await import(`${miloLibs}/utils/utils.js`);
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'dxdc' });
   await loadArea();
+
+  // Promotion from metadata (for FedPub)
+  const promotionMetadata = getMetadata('promotion');
+  if (promotionMetadata && !document.querySelector('main .promotion')) {
+    const { promotionFromMetadata } = await import('../blocks/promotion/promotion.js');
+    promotionFromMetadata(promotionMetadata);
+  }
+
   loadDelayed();
   lanaLogging();
 


### PR DESCRIPTION
Resolve: [MWPW-129216](https://jira.corp.adobe.com/browse/MWPW-129216)

Before: https://stage--dc--adobecom.hlx.page/acrobat/hub/how-to/how-to-convert-pdf-to-image
After: https://delay-promotion--dc--adobecom.hlx.page/acrobat/hub/how-to/how-to-convert-pdf-to-image

This will load promotion block that being added when metadata exists after loadArea().
Note that loadArea() includes loadPostLCP which means **_this promotion block will be loaded after loadPostLCP()_**.
If you see refresh and go page bottom quickly you will find the promotion block get loaded slowly after everything else.

@Blainegunn  I don't know the background context why we want to load this after everything else, but this will do what is being asked.