### PR TITLE
Improving LCP first load time.

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -180,9 +180,6 @@ function decoratePromotion() {
   const { setLibs } = await import('./utils.js');
   const miloLibs = setLibs(LIBS);
 
-  // Setup Logging
-  const { default: lanaLogging } = await import('./dcLana.js');
-
   // Setup CSP
   if (window.location.pathname.indexOf('online') > 0) {
     const { default: ContentSecurityPolicy } = await import('./contentSecurityPolicy/csp.js');
@@ -201,6 +198,9 @@ function decoratePromotion() {
   loadLana({ clientId: 'dxdc' });
   await loadArea();
   loadDelayed();
+
+  // Setup Logging
+  const { default: lanaLogging } = await import('./dcLana.js');
   lanaLogging();
 
   // IMS Ready


### PR DESCRIPTION
Moving the dcLana import right before the function get called so loadArea() doesn't have to wait the file get loaded.

before: https://stage--dc--adobecom.hlx.live/acrobat/online/pdf-to-ppt
after: https://lana--dc--adobecom.hlx.live/acrobat/online/pdf-to-ppt