### PR TITLE
DCXY-16330 remove overflow: hidden

### DIFF
--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -19,7 +19,6 @@
   margin: auto;
   padding: 0 0 0 ;
   position: relative;
-  overflow: hidden;
   left:0;
   top: 70px;
   right:0;


### PR DESCRIPTION
Removing overflow:hidden from the widget container in order to fix an issue with error toasts.  Do we know why this overflow:hidden was there in the first place?