### PR TITLE
Updating contentRoot to dc-shared: This will fix 404 and other issues.

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -145,7 +145,7 @@ const locales = {
 // Add any config options.
 const CONFIG = {
   codeRoot: '/acrobat',
-  contentRoot: '/',
+  contentRoot: '/dc-shared',
   imsClientId: 'acrobatmilo',
   local: { edgeConfigId: 'da46a629-be9b-40e5-8843-4b1ac848745c' },
   stage: { edgeConfigId: 'da46a629-be9b-40e5-8843-4b1ac848745c' },


### PR DESCRIPTION
Reslove: [MWPW-128858](https://jira.corp.adobe.com/browse/MWPW-128858)

US test URL
before: https://stage--dc--adobecom.hlx.page/foo
after: https://contentroot-dc-shared--dc--adobecom.hlx.page/foo

Other locale test (Korean)
before: https://stage--dc--adobecom.hlx.page/kr/foo
after: https://contentroot-dc-shared--dc--adobecom.hlx.page/kr/foo

This PR will update contentRoot to `/dc-shared`. It needs a decent QA to make sure nothing gets broken.
