### PR TITLE
Use franklin feature to add `x-default` hreflang

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -4,13 +4,8 @@ sitemaps:
   website:
     origin: https://www.adobe.com
     lastmod: YYYY-MM-DD
+    default: en-US
     languages:
-      default:
-        source: /dc-shared/assets/query-index.json
-        alternate: /{path}.html
-        destination: /dc-shared/assets/sitemap.xml
-        hreflang: x-default
-
       us:
         source: /dc-shared/assets/query-index.json
         alternate: /{path}.html


### PR DESCRIPTION
Still unsure if `us` entry needs `alternate` key or not. Need to read source more carefully: https://github.com/adobe/helix-admin/blob/main/src/sitemap/builder.js

Addresses: [MWPW-130622](https://jira.corp.adobe.com/browse/MWPW-130622). May may not fix duplicates but at least it will add missing `x-default`

URL for testing:

- https://hparra-patch-2--dc--adobecom.hlx.page/

Post-merge:

- Run `curl -vX POST https://admin.hlx.page/sitemap/adobecom/dc/main/dc-shared/assets/sitemap.xml`