### PR TITLE
Fix hreflangs for Hebrew, Thai, Hindi, English (India), Russian (Russia) and Simplified Chinese

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -340,13 +340,7 @@ sitemaps:
         destination: /bg/dc-shared/assets/sitemap.xml
         hreflang: bg-BG
 
-      ru:
-        source: /ru/dc-shared/assets/query-index.json
-        alternate: /ru/{path}.html
-        destination: /ru/dc-shared/assets/sitemap.xml
-        hreflang: ru-RU
-        
-      cis_ru_kz:
+      cis_ru:
         source: /ru/dc-shared/assets/query-index.json
         alternate: /ru/{path}.html
         destination: /ru/dc-shared/assets/sitemap.xml
@@ -357,6 +351,7 @@ sitemaps:
           - ru-KG
           - ru-KZ
           - ru-MD
+          - ru-RU
           - ru-TJ
           - ru-UZ
 
@@ -370,7 +365,7 @@ sitemaps:
         source: /il_he/dc-shared/assets/query-index.json
         alternate: /il_he/{path}.html
         destination: /il_he/dc-shared/assets/sitemap.xml
-        hreflang: he
+        hreflang: he-il
 
       ae_ar:
         source: /ae_ar/dc-shared/assets/query-index.json
@@ -400,7 +395,7 @@ sitemaps:
         source: /in/dc-shared/assets/query-index.json
         alternate: /in/{path}.html
         destination: /in/dc-shared/assets/sitemap.xml
-        hreflang: en-GB
+        hreflang: en-IN
 
       id_id:
         source: /id_id/dc-shared/assets/query-index.json
@@ -460,19 +455,21 @@ sitemaps:
         source: /in_hi/dc-shared/assets/query-index.json
         alternate: /in_hi/{path}.html
         destination: /in_hi/dc-shared/assets/sitemap.xml
-        hreflang: hi
+        hreflang: hi-IN
 
       th_th:
         source: /th_th/dc-shared/assets/query-index.json
         alternate: /th_th/{path}.html
         destination: /th_th/dc-shared/assets/sitemap.xml
-        hreflang: th
+        hreflang: th-TH
 
       cn:
         source: /cn/dc-shared/assets/query-index.json
         alternate: /cn/{path}.html
         destination: /cn/dc-shared/assets/sitemap.xml
-        hreflang: zh-CN
+        hreflang:
+          - zh-CN
+          - zh-Hans-CN
 
       hk_zh:
         source: /hk_zh/dc-shared/assets/query-index.json

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -365,7 +365,7 @@ sitemaps:
         source: /il_he/dc-shared/assets/query-index.json
         alternate: /il_he/{path}.html
         destination: /il_he/dc-shared/assets/sitemap.xml
-        hreflang: he-il
+        hreflang: he-IL
 
       ae_ar:
         source: /ae_ar/dc-shared/assets/query-index.json


### PR DESCRIPTION
Fix targeting for Hebrew and Thai so they only match Israel and Thailand (like dexter), fix misconfigured English and Hindi for India, consolidate Russian Russian and Simplified Chinese.

See validation at https://git.corp.adobe.com/rea50414/notebooks/blob/main/milo-sitemap-hrelang-yaml.ipynb 

Addresses: 

- https://jira.corp.adobe.com/browse/MWPW-129768
- https://jira.corp.adobe.com/browse/MWPW-129652
- https://jira.corp.adobe.com/browse/MWPW-130428

URL for testing:

- https://hparra-fix-sitemaps-again--dc--adobecom.hlx.page/

Post-merge:

- Run `curl -vX POST https://admin.hlx.page/sitemap/adobecom/dc/main/dc-shared/assets/sitemap.xml`

