### PR TITLE
textContent is better

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -113,7 +113,7 @@ export default function init(element) {
   }
 
   widget.querySelector('div').id = 'VERB';
-  const VERB = widget.querySelector('div').innerText.trim().toLowerCase();
+  const VERB = widget.querySelector('div').textContent.trim().toLowerCase();
 
   // Redir URL
   const REDIRECT_URL_DIV = widget.querySelectorAll('div')[2];


### PR DESCRIPTION
There are articles on Internet about innerText vs textContent. In addition, JSDOM doesn't support innerText (https://github.com/jsdom/jsdom/issues/1245).