### PR TITLE
MWPW-132502 remove z-index from CID, move .section behind to z-index -1

### DIFF
--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -7,7 +7,7 @@
  *
  */
 
- #dc-converter-widget {
+#dc-converter-widget {
   background-color: #fc6767;
   min-height: 570px;
 }
@@ -22,7 +22,6 @@
   left:0;
   top: 70px;
   right:0;
-  z-index: 1;
 }
 
 #VERB, .hide {
@@ -138,6 +137,10 @@
 
 .accordion-container.verb-subfooter-moblie  dd.is-open.has-focus {
   background-color: transparent;
+}
+
+.section {
+  z-index: -1;
 }
 
 .section.hide {


### PR DESCRIPTION
It would resolve this bug not to set the widget background z-index to 1, and it would seem to be far safer to avoid z-index conflicts with the react-spectrum library, in general.

Would moving all .section to z-index: -1 create any problems?