### PR TITLE
Implemented fix

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -208,7 +208,6 @@ const CONFIG = {
   addLocale(ietf);
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'dxdc' });
-  await loadArea();
 
   // Setup href of sign in
   const singInReady = setInterval(() => {
@@ -220,6 +219,8 @@ const CONFIG = {
     }
 
   }, 100);
+
+  await loadArea();
 
   // Promotion from metadata (for FedPub)
   const promotionMetadata = getMetadata('promotion');

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -213,7 +213,6 @@ const CONFIG = {
   const singInReady = setInterval(() => {
     const singIn = document.querySelector('.gnav-signin');
     if(singIn){
-      console.log(singIn);
       clearInterval(singInReady);
       singIn.setAttribute('href', '#');
     }

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -39,6 +39,17 @@ function addLocale(locale) {
   document.head.appendChild(metaTag);
 }
 
+function setupGnavItemsHref(selector) {
+  const gnavItemReady = setInterval(() => {
+    const gnavItem = document.querySelector(selector);
+    if(gnavItem){
+      clearInterval(gnavItemReady);
+      gnavItem.setAttribute('href', '#');
+    }
+
+  }, 100);
+}
+
 // Add project-wide styles here.
 const STYLES = '/acrobat/styles/styles.css';
 
@@ -210,14 +221,10 @@ const CONFIG = {
   loadLana({ clientId: 'dxdc' });
 
   // Setup href of sign in
-  const singInReady = setInterval(() => {
-    const singIn = document.querySelector('.gnav-signin');
-    if(singIn){
-      clearInterval(singInReady);
-      singIn.setAttribute('href', '#');
-    }
+  setupGnavItemsHref('.gnav-signin');
 
-  }, 100);
+  //Setup href of section menu
+  setupGnavItemsHref('.section-menu > a');
 
   await loadArea();
 

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -210,6 +210,17 @@ const CONFIG = {
   loadLana({ clientId: 'dxdc' });
   await loadArea();
 
+  // Setup href of sign in
+  const singInReady = setInterval(() => {
+    const singIn = document.querySelector('.gnav-signin');
+    if(singIn){
+      console.log(singIn);
+      clearInterval(singInReady);
+      singIn.setAttribute('href', '#');
+    }
+
+  }, 100);
+
   // Promotion from metadata (for FedPub)
   const promotionMetadata = getMetadata('promotion');
   if (promotionMetadata && !document.querySelector('main .promotion')) {


### PR DESCRIPTION
The gnav sign-in option comes from dc-shared/gnav.docx has a specified link that exists for US but does not exist for other locations. A regular click on the option redirects as expected, but opening the link in a new tab gives a 404. This fix sets the href attribute value to "#" which will open the same page in a new tab, without requiring authors to update the gnav links for all locales.
Also, this PR resolves issue with section menu which currently redirects to wrong page on new tab, while it should redirect to same page.
Resolves: [MWPW-132208](https://jira.corp.adobe.com/browse/MWPW-132208) and [MWPW-132728](https://jira.corp.adobe.com/browse/MWPW-132728)
Before: https://stage--dc--adobecom.hlx.page/de/acrobat/online/jpg-to-pdf
After: https://mwpw-132208-fix-gnav-signin-link--dc--adobecom.hlx.page/de/acrobat/online/jpg-to-pdf