### PR TITLE
MWPW-133578:Removed modalExist analytics event from modal:open

### DIFF
--- a/acrobat/scripts/frictionless.js
+++ b/acrobat/scripts/frictionless.js
@@ -56,7 +56,6 @@ export default function init(verb) {
         return;
       }
       clearInterval(extensionWait);
-      browserExtAlloy('modalExist', browserName);
       browserExtAlloy('modalGetExtension', browserName, 'impression');
 
       browserExtClose.addEventListener('click', () => {


### PR DESCRIPTION
Resolves: [MWPW-133578](https://jira.corp.adobe.com/browse/MWPW-133578)

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/pdf-to-word
After: https://mwpw-133578-analytics-event-firing-unexpectidly--dc--adobecom.hlx.page/acrobat/online/pdf-to-word