### PR TITLE
Revert "Merge pull request #287 from adobecom/ajs-csp"

### DIFF
--- a/acrobat/scripts/contentSecurityPolicy/csp.js
+++ b/acrobat/scripts/contentSecurityPolicy/csp.js
@@ -21,8 +21,7 @@ async function getCspEnv() {
 export default async function ContentSecurityPolicy() {
   const { default: ENV } = await getCspEnv();
 
-  const theCSP = `child-src ${ENV.childSrc.join(' ')}\
-  connect-src ${ENV.connectSrc.join(' ')}\
+  const theCSP = `connect-src ${ENV.connectSrc.join(' ')}\
   default-src ${ENV.defaultSrc.join(' ')}\
   font-src ${ENV.fontSrc.join(' ')}\
   form-action ${ENV.formAction.join(' ')}\

--- a/acrobat/scripts/contentSecurityPolicy/dev.js
+++ b/acrobat/scripts/contentSecurityPolicy/dev.js
@@ -1,9 +1,3 @@
-const childSrc = [
-  '\'self\'',
-  'blob:',
-  ';',
-];
-
 const connectSrc = [
   '\'self\'',
   'blob:',
@@ -231,4 +225,4 @@ const workerSrc = [
 // TRY This
 // use variables for the different domians
 
-export default { childSrc, connectSrc, defaultSrc, fontSrc, formAction, frameSrc, imgSrc, manifestSrc, scriptSrc, styleSrc, workerSrc};
+export default { connectSrc, defaultSrc, fontSrc, formAction, frameSrc, imgSrc, manifestSrc, scriptSrc, styleSrc, workerSrc};

--- a/acrobat/scripts/contentSecurityPolicy/prod.js
+++ b/acrobat/scripts/contentSecurityPolicy/prod.js
@@ -1,8 +1,3 @@
-const childSrc = [
-  '\'self\'',
-  ';',
-];
-
 const connectSrc = [
   '\'self\'',
   'blob:',
@@ -244,4 +239,4 @@ const workerSrc = [
   ';',
 ];
 
-export default { childSrc, connectSrc, defaultSrc, fontSrc, formAction, frameSrc, imgSrc, manifestSrc, scriptSrc, styleSrc, workerSrc};
+export default { connectSrc, defaultSrc, fontSrc, formAction, frameSrc, imgSrc, manifestSrc, scriptSrc, styleSrc, workerSrc};

--- a/acrobat/scripts/contentSecurityPolicy/stage.js
+++ b/acrobat/scripts/contentSecurityPolicy/stage.js
@@ -1,9 +1,3 @@
-const childSrc = [
-  '\'self\'',
-  'blob:',
-  ';',
-];
-
 const connectSrc = [
   '\'self\'',
   'blob:',
@@ -264,4 +258,4 @@ const workerSrc = [
   ';',
 ];
 
-export default { childSrc, connectSrc, defaultSrc, fontSrc, formAction, frameSrc, imgSrc, manifestSrc, scriptSrc, styleSrc, workerSrc};
+export default { connectSrc, defaultSrc, fontSrc, formAction, frameSrc, imgSrc, manifestSrc, scriptSrc, styleSrc, workerSrc};


### PR DESCRIPTION
It was determined that the child-src:blob setting was not needed to support fill & sign L2. the worker-src:blob setting is sufficient because everything is running on the same domain.

This reverts commit 7a34bed8f9d2b6e1e32af344405792825d51fa2e, reversing changes made to 65eda6d2b928fc9ee8e82885fabc88f73e8161ca.