### PR TITLE
Added padding for how-to block

### DIFF
--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -205,6 +205,7 @@ div.how-to {
     "image" !important;
   }
   .how-to-heading {
+    padding-top: 44px;
     margin-right: 0;
   }
   .how-to-image.how-to-image-large {
@@ -393,11 +394,5 @@ div.how-to ol li::before{
 
   .how-to-heading {
     padding-top: 52px;
-  }
-}
-
-@media (max-width: 599px) {
-  .how-to-heading {
-    padding-top: 44px;
   }
 }

--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -188,6 +188,16 @@ div.how-to {
   margin-right: 28px;
 }
 
+@media (max-width: 1200px) {
+  .how-to > .foreground {
+    padding-top: 80px !important;
+  }
+
+  .how-to-heading {
+    padding-top: 52px;
+  }
+}
+
 /* Moblie HowTo */
 @media (max-width: 600px) {
   .how-to.large-image {
@@ -385,14 +395,4 @@ div.how-to ol li::before{
   max-width: 600px;
   margin: auto;
   padding: 20px;
-}
-
-@media (max-width: 1200px) {
-  .how-to > .foreground {
-    padding-top: 80px !important;
-  }
-
-  .how-to-heading {
-    padding-top: 52px;
-  }
 }

--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -177,6 +177,7 @@ div.how-to {
 }
 
 .how-to-heading {
+  padding-top: 60px;
   margin-right: 28px;
 }
 .how-to-image.how-to-image-large {
@@ -385,4 +386,10 @@ div.how-to ol li::before{
   max-width: 600px;
   margin: auto;
   padding: 20px;
+}
+
+@media (max-width: 1200px) {
+  .how-to-heading {
+    padding-top: 52px;
+  }
 }

--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -196,8 +196,6 @@ div.how-to {
     "heading"
     "list" !important;
     grid-template-columns: 1fr !important;
-    padding-top: 56px;
-    padding-bottom: 56px;
   }
   /* Moblie HowTo word-to-pdf US ONLY */
   [data-path="/dc-shared/fragments/frictionless-personalization-xfs/word-to-pdf-xfs/how-to/default"] .how-to.large-image {
@@ -389,7 +387,17 @@ div.how-to ol li::before{
 }
 
 @media (max-width: 1200px) {
+  .how-to > .foreground {
+    padding-top: 80px !important;
+  }
+
   .how-to-heading {
     padding-top: 52px;
+  }
+}
+
+@media (max-width: 599px) {
+  .how-to-heading {
+    padding-top: 44px;
   }
 }

--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -177,9 +177,13 @@ div.how-to {
 }
 
 .how-to-heading {
-  padding-top: 60px;
   margin-right: 28px;
 }
+
+.eventwrapper .how-to-heading {
+  padding-top: 60px;
+}
+
 .how-to-image.how-to-image-large {
   margin-left: 28px;
 }
@@ -189,11 +193,11 @@ div.how-to {
 }
 
 @media (max-width: 1200px) {
-  .how-to > .foreground {
+  .eventwrapper .how-to > .foreground {
     padding-top: 80px !important;
   }
 
-  .how-to-heading {
+  .eventwrapper .how-to-heading {
     padding-top: 52px;
   }
 }
@@ -214,7 +218,7 @@ div.how-to {
     "list"
     "image" !important;
   }
-  .how-to-heading {
+  .eventwrapper .how-to-heading {
     padding-top: 44px;
     margin-right: 0;
   }


### PR DESCRIPTION
*Added padding to how-to block to fix overlapping on tablet devices + added additional padding for desktop devices to match previous design

Resolves: [MWPW-134277](https://jira.corp.adobe.com/browse/MWPW-134277)

Test URLs:

Before: https://stage--dc--adobecom.hlx.page/acrobat/online/word-to-pdf
After: https://mwpw-134277-fix-overlap--dc--adobecom.hlx.page/acrobat/online/word-to-pdf