### PR TITLE
DCXY-18423 add child-src:blob on prod for adobe proxy F&S support on old Safari <15.4

### DIFF
--- a/acrobat/scripts/contentSecurityPolicy/prod.js
+++ b/acrobat/scripts/contentSecurityPolicy/prod.js
@@ -1,5 +1,6 @@
 const childSrc = [
   '\'self\'',
+  'blob:',
   ';',
 ];
 


### PR DESCRIPTION
to support frictionless fill & sign.  worker-src:blob is usually sufficient for them to create their wasm proxies, but for old Safari we determined that child-src is also needed