### PR TITLE
replace hard-coded version with variable

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -210,9 +210,10 @@ const { ietf } = getLocale(locales);
       widgetBlock.removeAttribute('class');
       widgetBlock.id = 'dc-converter-widget'; 
       const DC_WIDGET_VERSION = document.querySelector('meta[name="dc-widget-version"]')?.getAttribute('content');
+      const [,DC_GENERATE_CACHE_VERSION] = DC_WIDGET_VERSION.split('_');
       const dcUrls = [
         `https://acrobat.adobe.com/dc-hosted/${DC_WIDGET_VERSION}/dc-app-launcher.js`,
-        `https://acrobat.adobe.com/dc-generate-cache/dc-hosted-2.10.2/${window.location.pathname.split('/').pop().split('.')[0]}-${ietf.toLowerCase()}.html`
+        `https://acrobat.adobe.com/dc-generate-cache/dc-hosted-${DC_GENERATE_CACHE_VERSION}/${window.location.pathname.split('/').pop().split('.')[0]}-${ietf.toLowerCase()}.html`
       ];
 
       dcUrls.forEach( url => {


### PR DESCRIPTION
dc-hosted/generate cache will always be the second half of the widget version tuple