### PR TITLE
MWPW-127299 use stage proxy dc urls

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -155,8 +155,8 @@ export default function init(element) {
     || window.location.hostname === 'stage--dc--adobecom.hlx.live'
     || window.location.hostname === 'main--dc--adobecom.hlx.live'
     || window.location.hostname === 'www.stage.adobe.com') {
-    WIDGET_ENV = `https://stage.acrobat.adobe.com/dc-hosted/${STG_DC_WIDGET_VERSION}/dc-app-launcher.js`;
-    DC_DOMAIN = 'https://stage.acrobat.adobe.com';
+    WIDGET_ENV = `https://www.stage.adobe.com/dc/dc-hosted/${STG_DC_WIDGET_VERSION}/dc-app-launcher.js`;
+    DC_DOMAIN = 'https://www.stage.adobe.com/dc';
     DC_GENERATE_CACHE_VERSION = STG_DC_GENERATE_CACHE_VERSION;
     ENV = 'stage';
   }


### PR DESCRIPTION
Test proxy urls on stage only. This will fetch DC widget assets from the same www.adobe.com host as the rest of the page and should eliminate delay.