### PR TITLE
MWPW-134643 - enable jarvis chat

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -185,7 +185,11 @@ const CONFIG = {
   locales,
   // geoRouting: 'on',
   prodDomains: ['www.adobe.com'],
-
+  jarvis: {
+    id: 'milo',
+    version: '1.0',
+    onDemand: false,
+  },
 };
 
 // Default to loading the first image as eager.


### PR DESCRIPTION
Resolves: https://jira.corp.adobe.com/browse/MWPW-134643
Documentation for authoring: https://milo.adobe.com/docs/authoring/jarvis

**Note:** 
The Jarvis icon will only show up on published pages. To test on preview pages, connect to VPN to see the chat icon.

