### PR TITLE
additional experiment: for one page (compress-pdf) skip prefetching of app-launcher

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -242,6 +242,7 @@ const { ietf } = getLocale(locales);
 
   // Fast track the widget
   const widgetBlock = document.querySelector('[class*="dc-converter-widget"]');
+  const pageName = window.location.pathname.split('/').pop().split('.')[0];
   if (widgetBlock) {
     const verb = widgetBlock.children[0].children[0]?.innerText?.trim();
     const blockName = widgetBlock.classList.value;
@@ -251,14 +252,18 @@ const { ietf } = getLocale(locales);
     const DC_GENERATE_CACHE_VERSION = document.querySelector('meta[name="dc-generate-cache-version"]')?.getAttribute('content');
     const dcUrls = [
       `https://www.adobe.com/dc/dc-generate-cache/dc-hosted-${DC_GENERATE_CACHE_VERSION}/${verb}-${ietf.toLowerCase()}.html`,
-      `https://acrobat.adobe.com/dc-hosted/${DC_WIDGET_VERSION}/dc-app-launcher.js`
     ];
+
+    // Experiment, don't prefetch app-launcher as it competes with fast path
+    if (pageName !== 'compress-pdf') {
+      dcUrls.push(`https://acrobat.adobe.com/dc-hosted/${DC_WIDGET_VERSION}/dc-app-launcher.js`);
+    }
 
     dcUrls.forEach( url => {
       const link = document.createElement('link');
       link.setAttribute('rel', 'prefetch');
       if(url.split('.').pop() === 'html') {link.setAttribute('as', 'fetch');}
-      if(url.split('.').pop() === 'js') {link.setAttribute('as', 'script');;}
+      if(url.split('.').pop() === 'js') {link.setAttribute('as', 'script');}
       link.setAttribute('href', url);
       link.setAttribute('crossorigin', '');
       document.head.appendChild(link);

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -242,7 +242,6 @@ const { ietf } = getLocale(locales);
 
   // Fast track the widget
   const widgetBlock = document.querySelector('[class*="dc-converter-widget"]');
-  const pageName = window.location.pathname.split('/').pop().split('.')[0];
   if (widgetBlock) {
     const verb = widgetBlock.children[0].children[0]?.innerText?.trim();
     const blockName = widgetBlock.classList.value;
@@ -255,7 +254,7 @@ const { ietf } = getLocale(locales);
     ];
 
     // Experiment, don't prefetch app-launcher as it competes with fast path
-    if (pageName !== 'compress-pdf') {
+    if (verb !== 'compress-pdf') {
       dcUrls.push(`https://acrobat.adobe.com/dc-hosted/${DC_WIDGET_VERSION}/dc-app-launcher.js`);
     }
 


### PR DESCRIPTION
dc-app-launcher.js is not needed for LCP since we are presenting the dc-generate-cache fragment to all users. Prefetching dc-app-launcher.js competes with other resources needed for LCP, so let's eliminate it.