### PR TITLE
MWPW-135275 Revert "Merge pull request #333 from adobecom/loadareatest4"

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -236,10 +236,6 @@ window.browser = getBrowserData();
 const { ietf } = getLocale(locales);
 
 (async function loadPage() {
-  // Load Milo base features
-  const miloLibs = setLibs(LIBS);
-  const utilsPromise = import(`${miloLibs}/utils/utils.js`);
-
   // Fast track the widget
   const widgetBlock = document.querySelector('[class*="dc-converter-widget"]');
   if (widgetBlock) {
@@ -276,21 +272,24 @@ const { ietf } = getLocale(locales);
     }
   })();
 
+  // Setup Milo
+  const miloLibs = setLibs(LIBS);
+
   // Milo and site styles
   const paths = [`${miloLibs}/styles/styles.css`];
   if (STYLES) { paths.push(STYLES); }
   loadStyles(paths);
 
-  // Run base milo features
+  // Import base milo features and run them
   const {
     loadArea, loadScript, setConfig, loadLana, getMetadata
-  } = await utilsPromise;
+  } = await import(`${miloLibs}/utils/utils.js`);
   addLocale(ietf);
 
   setConfig({ ...CONFIG, miloLibs });
   loadLana({ clientId: 'dxdc' });
 
-  // get event back from dc web and then load area
+  // get event back form dc web and then load area
   await loadArea(document, false);
 
   // Setup Logging


### PR DESCRIPTION
@auniverseaway kindly let us in on the secret that loadArea no longer hides our page.  Now we no longer need to prefetch utils.js to get loadArea done sooner.  This will not fix our waterfall, but it will push utils.js out later until most of our critical code is done.

This reverts commit c83a409bc9e1a450c4e03c06933dd351a181a181,

See #333 