### PR TITLE
fix(csp): enable RUM reporting

### DIFF
--- a/acrobat/scripts/contentSecurityPolicy/prod.js
+++ b/acrobat/scripts/contentSecurityPolicy/prod.js
@@ -45,6 +45,7 @@ const connectSrc = [
   '*.typekit.net/',
   'trial-eum-clienttons-s.akamaihd.net/',
   '*.akstat.io/',
+  'rum.hlx.page',
   ';',
 ];
 
@@ -227,6 +228,7 @@ const scriptSrc = [
   's.yjtag.jp/tag.js',
   's.yimg.jp',
   'yjtag.yahoo.co.jp',
+  'rum.hlx.page',
   ';',
 ];
 


### PR DESCRIPTION
We've been seeing CSP violations due to Franklin RUM requests being blocked. This commit allow-lists rum.hlx.page which is our RUM collection endpoint