### PR TITLE
MWPW-135029 - fixed exception 'chrome is not defined'

### DIFF
--- a/acrobat/blocks/eventwrapper/eventwrapper.js
+++ b/acrobat/blocks/eventwrapper/eventwrapper.js
@@ -43,7 +43,7 @@ export default function init(element) {
 
   const extInstalled = (extid, extname, browserName) => {
     const event = new CustomEvent('modal:open', { detail: { hash: extname } });
-    if (chrome.runtime && chrome.runtime.sendMessage) {
+    if (chrome?.runtime?.sendMessage) {
       chrome.runtime.sendMessage(extid, 'version', response => {
         if (!response) {
           window.dispatchEvent(event);


### PR DESCRIPTION
Resolves: https://jira.corp.adobe.com/browse/MWPW-135029

Fix for exception _ReferenceError: chrome is not defined_ when running automated tests in Playwight's headless mode

