### PR TITLE
MWPW-137403: Changed favicon icons path

### DIFF
--- a/acrobat/img/favicons/favicon.webmanifest
+++ b/acrobat/img/favicons/favicon.webmanifest
@@ -2,7 +2,7 @@
     "name": "Adobe Experience Cloud",
     "display": "standalone",
     "icons": [
-        { "src": "/img/favicons/favicon-192.png", "sizes": "192x192", "type": "image/png" },
-        { "src": "/img/favicons/favicon-512.png", "sizes": "512x512", "type": "image/png" }
+        { "src": "/acrobat/img/favicons/favicon-192.png", "sizes": "192x192", "type": "image/png" },
+        { "src": "/acrobat/img/favicons/favicon-512.png", "sizes": "512x512", "type": "image/png" }
     ]
 }


### PR DESCRIPTION
Resolves: [MWPW-137403](https://jira.corp.adobe.com/browse/MWPW-137403)
Before: https://stage--dc--adobecom.hlx.live/acrobat/online/pdf-to-ppt
After: https://mwpw-137403-favicon-404--dc--adobecom.hlx.live/acrobat/online/pdf-to-ppt