### PR TITLE
MWPW-136950: Fixed css preload warnings

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -106,6 +106,7 @@ function loadStyles(paths) {
     const link = document.createElement('link');
     link.setAttribute('rel', 'stylesheet');
     link.setAttribute('href', path);
+    link.setAttribute('crossorigin', 'anonymous');
     document.head.appendChild(link);
   });
 }


### PR DESCRIPTION
Resolves: [MWPW-136950](https://jira.corp.adobe.com/browse/MWPW-136950)

Before: https://stage--dc--adobecom.hlx.live/drafts/ratko/convert-pdf
After: https://mwpw-136950-preload-warnings--dc--adobecom.hlx.live/drafts/ratko/convert-pdf