### PR TITLE
MWPW-135236 Auto trigger test after SharePoint changes

### DIFF
--- a/.github/scripts/check_404.spec.js
+++ b/.github/scripts/check_404.spec.js
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+test.use({
+  contextOptions: {
+    userAgent: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36 ${process.env.USER_AGENT_SUFFIX}`,
+  },
+});
+
+test('Check links in a page', async ({ page }) => {
+  test.setTimeout(180000);
+
+  await page.goto(process.env.TEST_URL, { waitUntil: 'networkidle' });
+
+  const allHrefs = await page.evaluate(() => {
+    return Array.from(document.links).map((item) => item.href);
+  });
+
+  const hrefs = [...new Set(allHrefs)].sort();
+
+  let output = [];
+  for (let i = 0; i < hrefs.length; i++) {
+    try {
+      const response = await page.goto(hrefs[i]);
+
+      for (
+        let request = response.request();
+        request;
+        request = request.redirectedFrom()
+      ) {
+        const message = `${(
+          await request.response()
+        ).status()} ${request.url()}`;
+        console.log(message);
+        output.push(message);
+      }
+    } catch {
+      const message = `999 ${hrefs[i]} no errorcode, offline?`;
+      console.log(message);
+      output.push(message);
+    }
+  }
+
+  await page.close();
+
+  const errors999 = output.filter((item) => item.startsWith('999'));
+  if (errors999.length > 0) {
+    console.log('\n999 errors:');
+    for (let i = 0; i < errors999.length; i++) {
+      console.log(errors999[i]);
+    }
+  }
+  const errors404 = output.filter((item) => item.startsWith('404'));
+  if (errors404.length > 0) {
+    console.log('\n404 errors:');
+    for (let i = 0; i < errors404.length; i++) {
+      console.log(errors404[i]);
+    }
+  }
+  expect(errors404).toHaveLength(0);
+});

--- a/.github/scripts/notify_slack.js
+++ b/.github/scripts/notify_slack.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+
+async function main() {
+  let diffJson;
+
+  if (process.argv.length === 3) {
+    diffJson = process.argv[2];
+  } else {
+    console.error('Usage: node notify_slack.js [diff.json]');
+    process.exit(1);
+  }
+
+  let diffs = [];
+
+  if (diffJson && fs.existsSync(diffJson)) {
+    diffs = JSON.parse(fs.readFileSync(diffJson));
+  }
+
+  if (
+    diffs.added.length === 0 &&
+    diffs.removed.length === 0 &&
+    diffs.changed.length === 0
+  ) {
+    return;
+  }
+
+  let message = '';
+
+  if (diffs.added.length > 0) {
+    message += `*Added: ${diffs.added.length}*\n`;
+    message += diffs.added
+      .map((x) => `* <https://www.adobe.com${x}|${x}>`)
+      .join('\n');
+  }
+  if (diffs.removed.length > 0) {
+    message += `*Removed: ${diffs.removed.length}*\n`;
+    message += diffs.removed
+      .map((x) => `* <https://www.adobe.com${x}|${x}>`)
+      .join('\n');
+  }
+  if (diffs.changed.length > 0) {
+    message += `*Changed: ${diffs.changed.length}*\n`;
+    message += diffs.changed
+      .map((x) => `* <https://www.adobe.com${x}|${x}>`)
+      .join('\n');
+  }
+
+  console.log(message);
+
+  fetch(`https://hooks.slack.com/services/${process.env.SLACK_WEBHOOK}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      text: message,
+    }),
+  }).then((response) => {
+    if (response.ok) {
+      return response.text();
+    } else {
+      throw new Error('Something went wrong');
+    }
+  });
+}
+
+main();

--- a/.github/scripts/query_index.js
+++ b/.github/scripts/query_index.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+
+async function queryIndex(url) {
+  let results = [];
+  let data = {
+    offset: 0,
+    limit: 0,
+    total: 1,
+  }
+  while (data.offset + data.limit < data.total) {
+    const resp = await fetch(
+      url + `?offset=${data.offset + data.limit}`
+    );
+    if (!resp.ok) break;
+    data = await resp.json();
+    results = results.concat(data.data);
+  }
+  return results;
+}
+
+async function main() {
+  let outputJson;
+  let baseJson;
+  if (process.argv.length === 4) {
+    outputJson = process.argv[2];
+    baseJson = process.argv[3];
+  } else if (process.argv.length === 3) {
+    outputJson = process.argv[2];    
+  } else {
+    console.error('Usage: node query_index.js [output.json] [base.json]');
+    process.exit(1);
+  }
+
+  let baseUrls = [];
+
+  if (baseJson && fs.existsSync(baseJson)) {
+    baseUrls = JSON.parse(fs.readFileSync(baseJson));
+  }
+
+  const queryIndexUrl =
+    'https://www.adobe.com/dc-shared/assets/query-index.json';
+  const urls = await queryIndex(queryIndexUrl);
+  
+  fs.writeFileSync(outputJson, JSON.stringify(urls, null, 2));
+  
+  const urlMap = {};
+  for (const url of urls) {
+    urlMap[url.path] = url;
+  }
+
+  const baseUrlMap = {};
+  for (const url of baseUrls) {
+    baseUrlMap[url.path] = url;
+  }
+
+  const diff = {
+    added: [],
+    removed: [],
+    changed: [],
+  }
+  for (const path in urlMap) {
+    if (!baseUrlMap[path]) {
+      diff.added.push(path);
+    } else if (urlMap[path].lastModified !== baseUrlMap[path].lastModified) {
+      diff.changed.push(path);
+    }
+  }
+  for (const path in baseUrlMap) {
+    if (!urlMap[path]) {
+      diff.removed.push(path);
+    }
+  }
+
+  fs.writeFileSync('diff.json', JSON.stringify(diff, null, 2));
+}
+
+main();

--- a/.github/scripts/query_metadata.js
+++ b/.github/scripts/query_metadata.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+
+async function queryIndex(url) {
+  let results = [];
+  let data = {
+    offset: 0,
+    limit: 0,
+    total: 1,
+  }
+  while (data.offset + data.limit < data.total) {
+    const resp = await fetch(
+      url + `?offset=${data.offset + data.limit}`
+    );
+    if (!resp.ok) break;
+    data = await resp.json();
+    results = results.concat(data.data);
+  }
+  return results;
+}
+
+function diffKeys(a, b) {
+  const diffs = [];
+  const keys = new Set(Object.keys(a).concat(Object.keys(b)));
+  for (const key of keys) {
+    if (a[key] !== b[key]) {
+      diffs.push(key);
+    }
+  }
+  return diffs;
+}
+
+async function main() {
+  let outputJson;
+  let baseJson;
+  let filename;
+  if (process.argv.length === 5) {
+    filename = process.argv[2];
+    outputJson = process.argv[3];
+    baseJson = process.argv[4];
+  } else if (process.argv.length === 4) {
+    filename = process.argv[2];    
+    outputJson = process.argv[3];    
+  } else {
+    console.error('Usage: node query_metadata.js [filename] [output.json] [base.json]');
+    process.exit(1);
+  }
+
+  let baseUrls = [];
+
+  if (baseJson && fs.existsSync(baseJson)) {
+    baseUrls = JSON.parse(fs.readFileSync(baseJson));
+  }
+
+  filename = filename.replace(/^\/+/, '');
+
+  const queryIndexUrl =
+    `https://main--dc--adobecom.hlx.live/${filename}`;
+  const urls = await queryIndex(queryIndexUrl);
+  
+  fs.writeFileSync(outputJson, JSON.stringify(urls, null, 2));
+  
+  const urlMap = {};
+  for (const url of urls) {
+    urlMap[url.URL] = url;
+  }
+
+  const baseUrlMap = {};
+  for (const url of baseUrls) {
+    baseUrlMap[url.URL] = url;
+  }
+
+  const diff = {
+    added: [],
+    removed: [],
+    changed: [],
+  }
+  for (const path in urlMap) {
+    if (!baseUrlMap[path]) {
+      diff.added.push(path);
+    } else if (JSON.stringify(urlMap[path]) !== JSON.stringify(baseUrlMap[path])) {
+      const keys = diffKeys(urlMap[path], baseUrlMap[path]);
+      diff.changed.push(`${path} (${keys.join(', ')})`);
+    }
+  }
+  for (const path in baseUrlMap) {
+    if (!urlMap[path]) {
+      diff.removed.push(path);
+    }
+  }
+
+  fs.writeFileSync(`diff_${filename}`, JSON.stringify(diff, null, 2));
+}
+
+main();

--- a/.github/workflows/metadata-published.yml
+++ b/.github/workflows/metadata-published.yml
@@ -1,0 +1,78 @@
+name: Metadata Published
+
+# Franklin Sidekick will trigger this workflow when a resource is published
+on: 
+  repository_dispatch:
+    types:
+      - resource-published
+
+jobs:
+  find-metadata-diff:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Show Event Payload
+      run: |
+        echo "Status: ${{ github.event.client_payload.status }}"
+        echo "Path: ${{ github.event.client_payload.path }}"
+    - name: Download artifact
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: metadata-published.yml
+        workflow_conclusion: success
+        name: base-query-metadata-cache
+        if_no_artifact_found: ignore
+        github_token: ${{ secrets.DC_PAT }}  
+    - name: Query Metadata
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: node .github/scripts/query_metadata.js metadata.json query_metadata.json query_metadata.json
+    - name: Query Metadata
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: node .github/scripts/query_metadata.js metadata-eng.json query_metadata-eng.json query_metadata-eng.json
+    - name: Query Metadata
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: node .github/scripts/query_metadata.js metadata-stage-eng.json query_metadata-stage-eng.json query_metadata-stage-eng.json
+    - uses: actions/upload-artifact@v3
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}    
+      with:
+        name: base-query-metadata-cache
+        path: |
+          query_metadata.json
+          query_metadata-eng.json
+          query_metadata-stage-eng.json
+    - name: List Diff of metadata.json
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: cat diff_metadata.json
+    - name: List Diff of metadata-eng.json
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: cat diff_metadata-eng.json
+    - name: List Diff of metadata-stage-eng.json
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: cat diff_metadata-stage-eng.json
+    - name: Slack Notification
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: node .github/scripts/notify_slack.js diff_metadata.json
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    - name: Slack Notification
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: node .github/scripts/notify_slack.js diff_metadata-eng.json
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    - name: Slack Notification
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      run: node .github/scripts/notify_slack.js diff_metadata-stage-eng.json
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}                    
+    - name: Trigger DC Workflow
+      if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.DC_PAT }}
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: 'adobecom',
+            repo: 'dc',
+            workflow_id: 'test-milo.yml',
+            ref: 'main',
+          })      

--- a/.github/workflows/page-published.yml
+++ b/.github/workflows/page-published.yml
@@ -28,7 +28,45 @@ jobs:
           path: query_index.json        
       - name: List Diff
         run: cat diff.json
+      - id: get-added-page
+        run: |
+          page=$( jq '.added[0]' diff.json )
+          echo "::set-output name=added_page::$page"
+      - id: get-changed-page
+        run: |
+          page=$( jq '.changed[0]' diff.json )
+          echo "::set-output name=changed_page::$page"             
       - name: Slack Notification
         run: node .github/scripts/notify_slack.js diff.json
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}        
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Trigger DC Workflow for Added Page
+        if: ${{ steps.get-added-page.outputs.added_page }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DC_PAT }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'adobecom',
+              repo: 'dc',
+              workflow_id: 'test-page-published.yml',
+              ref: 'main',
+              inputs: {
+                test_url: 'https://www.adobe.com${{ steps.get-added-page.outputs.added_page }}'
+              },              
+            })
+      - name: Trigger DC Workflow for Changed Page
+        if: ${{ steps.get-changed-page.outputs.changed_page }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DC_PAT }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'adobecom',
+              repo: 'dc',
+              workflow_id: 'test-page-published.yml',
+              ref: 'main',
+              inputs: {
+                test_url: 'https://www.adobe.com${{ steps.get-changed-page.outputs.changed_page }}'
+              },              
+            })                          

--- a/.github/workflows/page-published.yml
+++ b/.github/workflows/page-published.yml
@@ -1,0 +1,34 @@
+name: Page Published
+
+# Power Automate will trigger this workflow when the query index is modified
+# Query index is modified when a page is published
+on:
+  repository_dispatch:
+    types: [page_modified]
+  
+jobs:  
+  find-page-diff:
+    name: Find Page Diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: page-published.yml
+          workflow_conclusion: success
+          name: base-query-index-cache
+          if_no_artifact_found: ignore
+          github_token: ${{ secrets.DC_PAT }}
+      - name: Query Index
+        run: node .github/scripts/query_index.js query_index.json query_index.json
+      - uses: actions/upload-artifact@v3
+        with:
+          name: base-query-index-cache
+          path: query_index.json        
+      - name: List Diff
+        run: cat diff.json
+      - name: Slack Notification
+        run: node .github/scripts/notify_slack.js diff.json
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}        

--- a/.github/workflows/test-page-published.yml
+++ b/.github/workflows/test-page-published.yml
@@ -1,0 +1,40 @@
+name: Test Published Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_url:
+        description: 'Test URL'
+        required: true
+        default: 'https://www.adobe.com/'
+
+jobs:
+  run-tests:
+    name: Running tests
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.37.0-jammy
+
+    steps: 
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+
+    - name: Cache dependencies
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: ./node_modules
+        key: modules-${{ hashFiles('package-lock.json') }}-${{ runner.os }}
+
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: npm ci --ignore-scripts
+
+    - name: Run tests
+      run: npx playwright test .github/scripts/check_404.spec.js
+      env:
+        USER_AGENT_SUFFIX: "${{ secrets.USER_AGENT_SUFFIX }}"
+        TEST_URL: "${{ github.event.inputs.test_url }}"
+     


### PR DESCRIPTION
- The scripts are tested partially and locally. The integration of workflows can only be done after this PR is merged to the main branch. Some fixes and tuning may be needed then.
- Metadata and page changes are handled differently in this solution.

**Metadata Change**

When a resource is published in SharePoint, the helix-bot will create a workflow dispatch to the repo. The workflow `metadata-published.yml` compares the current to the previous metadata, and triggers the tests. 

The repo to be notified is configured in `admin.events.github.target` (see https://www.hlx.live/docs/configuration). If this value is not set, the repo configured in the AEM Sidekick is used.

**Page Change**

In order to have an insight on what pages are added, modified, and removed, we monitor the query index. 

When a page is published in SharePoint, the query index will be updated. A Power Automate flow is configured to watch the query index and trigger the workflow `page-published.yml`. The workflow compares the current to the previous query index and trigger the tests. 

The repo to be notified is configured in the Power Automate flow.