### PR TITLE
MWPW-138331: Fixed canonical url for .ing pages

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -254,6 +254,7 @@ const CONFIG = {
     version: '1.0',
     onDemand: false,
   },
+  ...(hostname.endsWith('.ing') && { useDotHtml: true }), // Adding .html to canonical url for .ing pages
 };
 
 // Default to loading the first image as eager.


### PR DESCRIPTION
https://github.com/adobecom/milo/blob/main/libs/utils/utils.js#L201
https://github.com/adobecom/milo/blob/main/libs/utils/utils.js#L293

Resolves: [MWPW-138331](https://jira.corp.adobe.com/browse/MWPW-138331)

Before: https://stage--dc--adobecom.hlx.live/acrobat/online/sign-pdf
After:  https://mwpw-138331-canonical-url-ing-pages--dc--adobecom.hlx.live/acrobat/online/sign-pdf