### PR TITLE
MWPW-138331: Fixed canonical url bug

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -111,6 +111,12 @@ if (hostname === 'www.stage.adobe.com') {
   document.head.appendChild(tokenElement);
 }
 
+// Adding .html to canonical url for .ing pages
+if (hostname.endsWith('.ing')) {
+  const canonEl = document.head.querySelector('link[rel="canonical"]');
+  canonEl?.setAttribute('href', `${canonEl.href}.html`);
+}
+
 function loadStyles(paths) {
   paths.forEach((path) => {
     const link = document.createElement('link');
@@ -254,7 +260,6 @@ const CONFIG = {
     version: '1.0',
     onDemand: false,
   },
-  ...(hostname.endsWith('.ing') && { useDotHtml: true }), // Adding .html to canonical url for .ing pages
 };
 
 // Default to loading the first image as eager.

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -114,7 +114,7 @@ if (hostname === 'www.stage.adobe.com') {
 // Adding .html to canonical url for .ing pages
 if (hostname.endsWith('.ing')) {
   const canonEl = document.head.querySelector('link[rel="canonical"]');
-  canonEl?.setAttribute('href', `${canonEl.href}.html`);
+  if (!canonEl?.href.endsWith('.html')) canonEl?.setAttribute('href', `${canonEl.href}.html`);
 }
 
 function loadStyles(paths) {


### PR DESCRIPTION
https://github.com/adobecom/milo/blob/main/libs/utils/utils.js#L301
I overlooked this line, pathname for sign.ing is `/` and canonical url pathname is `/acrobat/online/sign-pdf`, so adding `useDotHtml: true` doesn't work.

Resolves: [MWPW-138331](https://jira.corp.adobe.com/browse/MWPW-138331)

Before: https://stage--dc--adobecom.hlx.live/acrobat/online/sign-pdf
After: https://mwpw-138331-canonical-url-ing-pages--dc--adobecom.hlx.live/acrobat/online/sign-pdf