### PR TITLE
DCXY-19397: Don't pre-render dropzone when l2 limit is hit and upsell is shown

### DIFF
--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -126,7 +126,7 @@ const exhLimitCookieMap = {
 };
 
 const url = window.location;
-const cookies = document.cookie;
+const { cookie } = document;
 
 const langFromPath = url.pathname.split('/')[1];
 const pageLang = localeMap[langFromPath] || 'en-us';

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -115,7 +115,7 @@ const verbRedirMap = {
 
 const exhCreateLimitCookie = 'cr_p_c_e';
 const exhExportLimitCookie = 'ex_p_c_e';
-const exhOrganizeLimitCookie = 'org_p_c_e';
+const exhOrganizeLimitCookie = 'or_p_c_e';
 const exhCompressLimitCookie = 'cm_p_ops_e';
 
 const exhLimitCookieMap = {

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -113,20 +113,16 @@ const verbRedirMap = {
   'number-pages': 'number',
 };
 
-const exhCreateLimitCookie = 'cr_p_c_e';
-const exhExportLimitCookie = 'ex_p_c_e';
-const exhOrganizeLimitCookie = 'or_p_c_e';
-const exhCompressLimitCookie = 'cm_p_ops_e';
-
 const exhLimitCookieMap = {
-  'to-pdf': exhCreateLimitCookie,
-  'pdf-to': exhExportLimitCookie,
-  'compress-pdf': exhCompressLimitCookie,
-  'rotate-pages': exhOrganizeLimitCookie,
+  'createpdf': 'cr_p_c_e',
+  'to-pdf': 'cr_p_c_e',
+  'pdf-to': 'ex_p_c_e',
+  'compress-pdf': 'cm_p_ops_e',
+  'rotate-pages': 'or_p_c_e',
 };
 
 const url = window.location;
-const { cookie } = document;
+const { cookie: cookies } = document;
 
 const langFromPath = url.pathname.split('/')[1];
 const pageLang = localeMap[langFromPath] || 'en-us';
@@ -220,7 +216,6 @@ export default async function init(element) {
   widgetContainer.className = `fsw wapper-${VERB}`;
   widget.appendChild(widgetContainer);
 
-  const isReturningUser = window.localStorage.getItem('pdfnow.auth');
   const isRedirection = /redirect_(?:conversion|files)=true/.test(window.location.search);
   let isLimitExhausted = false;
   const isExportVerb = VERB.includes('pdf-to');
@@ -233,10 +228,7 @@ export default async function init(element) {
     isLimitExhausted = cookies.includes(exhLimitCookieMap['to-pdf']);
   }
 
-  const verbIncludeList = ['compress-pdf', 'fillsign', 'sendforsignature', 'add-comment',
-    'delete-pages', 'reorder-pages', 'split-pdf', 'insert-pdf', 'extract-pages', 'crop-pages', 'number-pages'];
-
-  const preRenderDropZone = verbIncludeList.includes(VERB) || (!isReturningUser && !isRedirection);
+  const preRenderDropZone = !isLimitExhausted && !isRedirection;
 
   const INLINE_SNIPPET = widget.querySelector(':scope > section#edge-snippet');
   if (INLINE_SNIPPET) {
@@ -244,7 +236,7 @@ export default async function init(element) {
     widgetContainer.appendChild(...INLINE_SNIPPET.childNodes);
     widget.removeChild(INLINE_SNIPPET);
     performance.mark('milo-move-snippet');
-  } else if (!isLimitExhausted && preRenderDropZone) {
+  } else if (preRenderDropZone) {
     const response = await fetch(DC_GENERATE_CACHE_URL || `${DC_DOMAIN}/dc-generate-cache/dc-hosted-${DC_GENERATE_CACHE_VERSION}/${VERB}-${pageLang}.html`);
     switch (response.status) {
       case 200: {

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -219,7 +219,7 @@ export default async function init(element) {
   const isRedirection = /redirect_(?:conversion|files)=true/.test(window.location.search);
   let isLimitExhausted = false;
   const isExportVerb = VERB.includes('pdf-to');
-  const isCreateVerb = VERB.includes('to-pdf');
+  const isCreateVerb = VERB.includes('to-pdf') || VERB === 'createpdf';
   if (exhLimitCookieMap[VERB]) {
     isLimitExhausted = cookies.includes(exhLimitCookieMap[VERB]);
   } else if (isExportVerb) {

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -114,7 +114,6 @@ const verbRedirMap = {
 };
 
 const exhLimitCookieMap = {
-  'createpdf': 'cr_p_c_e',
   'to-pdf': 'cr_p_c_e',
   'pdf-to': 'ex_p_c_e',
   'compress-pdf': 'cm_p_ops_e',

--- a/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
+++ b/acrobat/blocks/dc-converter-widget/dc-converter-widget.js
@@ -218,8 +218,8 @@ export default async function init(element) {
 
   const isRedirection = /redirect_(?:conversion|files)=true/.test(window.location.search);
   let isLimitExhausted = false;
-  const isExportVerb = VERB.includes('pdf-to');
-  const isCreateVerb = VERB.includes('to-pdf') || VERB === 'createpdf';
+  const isExportVerb = VERB.startsWith('pdf-to');
+  const isCreateVerb = VERB.endsWith('to-pdf') || VERB === 'createpdf';
   if (exhLimitCookieMap[VERB]) {
     isLimitExhausted = cookies.includes(exhLimitCookieMap[VERB]);
   } else if (isExportVerb) {


### PR DESCRIPTION
DC Web will keep a set of cookies for when a limit has been reached. We can check this cookie to predict whether an upsell will be shown and only pre-render the dropzone if that cookie is not set.

merged from [kbenelli-adobe:DCXY-19397-New](https://github.com/kbenelli-adobe/dc/tree/DCXY-19397-New)

@kbenelli-adobe 