### PR TITLE
MWPW-139266 - Added feature key window.dc_hosted.disableExtensionBanner

### DIFF
--- a/acrobat/blocks/eventwrapper/eventwrapper.js
+++ b/acrobat/blocks/eventwrapper/eventwrapper.js
@@ -14,6 +14,7 @@ const PREVIEW_DIS = 'preview-displayed';
 const TRY_ANOTHER = 'try-another-file-start';
 // const UPSELL_DIS = 'upsell-displayed';
 const FADE = 'review fade-in';
+const DISABLE_EXTENSION_BANNER = window.dc_hosted.disableExtensionBanner === true;
 
 export default function init(element) {
   const wrapper = element;
@@ -72,14 +73,14 @@ export default function init(element) {
       // Browser Extension
       if (!localStorage.fricBrowExt) {
         let extName;
-        if (browserName === 'Chrome' && !window.modalDisplayed) {
+        if (browserName === 'Chrome' && !window.modalDisplayed && !DISABLE_EXTENSION_BANNER) {
           window.modalDisplayed = true;
           extName = '#chromeext';
           extID = 'efaidnbmnnnibpcajpcglclefindmkaj';
           extInstalled(extID, extName, browserName);
         }
 
-        if (browserName === 'Microsoft Edge' && !window.modalDisplayed) {
+        if (browserName === 'Microsoft Edge' && !window.modalDisplayed && !DISABLE_EXTENSION_BANNER) {
           window.modalDisplayed = true;
           extName = '#edgeext';
           extID = 'elhekieabhbkpmcefcoobjddigjcaadp';

--- a/acrobat/blocks/eventwrapper/eventwrapper.js
+++ b/acrobat/blocks/eventwrapper/eventwrapper.js
@@ -14,7 +14,6 @@ const PREVIEW_DIS = 'preview-displayed';
 const TRY_ANOTHER = 'try-another-file-start';
 // const UPSELL_DIS = 'upsell-displayed';
 const FADE = 'review fade-in';
-const DISABLE_EXTENSION_BANNER = window.dc_hosted.disableExtensionBanner === true;
 
 export default function init(element) {
   const wrapper = element;
@@ -73,14 +72,14 @@ export default function init(element) {
       // Browser Extension
       if (!localStorage.fricBrowExt) {
         let extName;
-        if (browserName === 'Chrome' && !window.modalDisplayed && !DISABLE_EXTENSION_BANNER) {
+        if (browserName === 'Chrome' && !window.modalDisplayed && window.dc_hosted.disableExtensionBanner !== true) {
           window.modalDisplayed = true;
           extName = '#chromeext';
           extID = 'efaidnbmnnnibpcajpcglclefindmkaj';
           extInstalled(extID, extName, browserName);
         }
 
-        if (browserName === 'Microsoft Edge' && !window.modalDisplayed && !DISABLE_EXTENSION_BANNER) {
+        if (browserName === 'Microsoft Edge' && !window.modalDisplayed && window.dc_hosted.disableExtensionBanner !== true) {
           window.modalDisplayed = true;
           extName = '#edgeext';
           extID = 'elhekieabhbkpmcefcoobjddigjcaadp';


### PR DESCRIPTION
Resolves:
https://jira.corp.adobe.com/browse/MWPW-139266

**LINKS:**
Before:
- https://stage--dc--adobecom.hlx.live/acrobat/online/excel-to-pdf
- https://stage--dc--adobecom.hlx.live/acrobat/online/rotate-pdf

After:
- https://mwpw-139266-new-browser-ext-toast-feature-key--dc--adobecom.hlx.live/acrobat/online/excel-to-pdf
- https://mwpw-139266-new-browser-ext-toast-feature-key--dc--adobecom.hlx.live/acrobat/online/rotate-pdf

**NOTE:**
If the feature key **window.dc_hosted.disableChromeExtensionBanner** is set to true, browser extension toast will pop up; otherwise, the the regular browser extension modal will appear.
The feature key has not been implemented yet on the widget side. The expected date is around December 7th. Before its implementation, all verbs should work as before. Once the implementation is complete, only pages where window.dc_hosted.disableChromeExtensionBanner = true is detected (currently, just **excel-to-pdf**) will have new behaviour with browser extension pop-up.