### PR TITLE
MWPW-139059 Issue with styling and privacy string

### DIFF
--- a/acrobat/scripts/contentSecurityPolicy/dev.js
+++ b/acrobat/scripts/contentSecurityPolicy/dev.js
@@ -92,6 +92,7 @@ const frameSrc = [
   'accounts.google.com',
   'adobe.demdex.net',
   'bid.g.doubleclick.net',
+  'td.doubleclick.net',
   'commerce-stg.adobe.com',
   'dc-api-dev.adobecontent.io',
   'dc.dev.dexilab.acrobat.com',
@@ -115,6 +116,7 @@ const imgSrc = [
   'blob:',
   'data:',
   '*.clarity.ms',
+  '*.enterprise.adobe.com',
   '*.services.adobe.com',
   'alb.reddit.com/rp.gif',
   'bat.bing.com/action/',
@@ -163,6 +165,7 @@ const manifestSrc = [
 
 const scriptSrc = [
   '\'self\'',
+  '\'unsafe-inline\'',
   '\'unsafe-eval\'',
   '*.adobe.com',
   '*.clarity.ms',

--- a/acrobat/scripts/contentSecurityPolicy/prod.js
+++ b/acrobat/scripts/contentSecurityPolicy/prod.js
@@ -84,6 +84,7 @@ const frameSrc = [
   'acrobat.adobe.com',
   'adobe.demdex.net',
   'bid.g.doubleclick.net',
+  'td.doubleclick.net',
   'commerce.adobe.com',
   'dc-api.adobecontent.io',
   'documentcloud.adobe.com',
@@ -107,6 +108,7 @@ const imgSrc = [
   'blob:',
   'data:',
   '*.clarity.ms',
+  '*.enterprise.adobe.com',
   '*.services.adobe.com',
   'alb.reddit.com/rp.gif',
   'analytics.twitter.com/',
@@ -159,6 +161,7 @@ const manifestSrc = [
 
 const scriptSrc = [
   '\'self\'',
+  '\'unsafe-inline\'',
   '\'unsafe-eval\'',
   '*.adobe.com',
   '*.clarity.ms',

--- a/acrobat/scripts/contentSecurityPolicy/stage.js
+++ b/acrobat/scripts/contentSecurityPolicy/stage.js
@@ -95,6 +95,7 @@ const frameSrc = [
   'accounts.google.com',
   'adobe.demdex.net',
   'bid.g.doubleclick.net',
+  'td.doubleclick.net',
   'commerce-stg.adobe.com',
   'dc-api-stage.adobecontent.io',
   'dc-api.adobecontent.io',
@@ -118,6 +119,7 @@ const imgSrc = [
   'data:',
   '*.adobe.com',
   '*.clarity.ms',
+  '*.enterprise.adobe.com',
   '*.services.adobe.com',
   'alb.reddit.com/rp.gif',
   's.tgm.yahoo-net.jp',
@@ -169,6 +171,7 @@ const manifestSrc = [
 
 const scriptSrc = [
   '\'self\'',
+  '\'unsafe-inline\'',
   '\'unsafe-eval\'',
   '*.adobe.com',
   '*.clarity.ms',


### PR DESCRIPTION
#### Changes Made:

- Content policies added to dev, stage & prod

#### How to Test:

1. Open a [milo form](https://mwpw-139699--dc--adobecom.hlx.page/drafts/rivero/faas-milo).
2. Verify that the form's styling is now consistent with the production version: [Production Form](https://www.adobe.com/creativecloud/business/teams/request-information.html).
3. Confirm that the privacy strings have been removed

#### Screenshots:
##### Before
<img width="2052" alt="Screenshot 2023-12-12 at 3 14 20 PM" src="https://github.com/adobecom/dc/assets/194010/5389a234-00b4-48c0-882f-b49752366826">

##### After
<img width="2056" alt="Screenshot 2023-12-12 at 3 15 02 PM" src="https://github.com/adobecom/dc/assets/194010/a7cd4c72-1946-494a-9773-7cd58719c9f6">


Resolves: [MWPW-139059](https://jira.corp.adobe.com/browse/MWPW-139059)

Test URLs:

Before: https://main--dc--adobecom.hlx.page/drafts/rivero/faas-milo
After: https://mwpw-139699--dc--adobecom.hlx.page/drafts/rivero/faas-milo
