### PR TITLE
MWPW-139879: Fixed widget cache preloading issue

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -294,7 +294,7 @@ const { ietf } = getLocale(locales);
 
     dcUrls.forEach((url) => {
       const link = document.createElement('link');
-      link.setAttribute('rel', 'prefetch');
+      link.setAttribute('rel', 'preload');
       if (url.split('.').pop() === 'html') { link.setAttribute('as', 'fetch'); }
       if (url.split('.').pop() === 'js') { link.setAttribute('as', 'script'); }
       link.setAttribute('href', url);


### PR DESCRIPTION
Resolves: [MWPW-139879](https://jira.corp.adobe.com/browse/MWPW-139879)

Before: https://mwpw-139879-fix-lcp--dc--adobecom.hlx.live/acrobat/online/pdf-to-word
After: https://stage--dc--adobecom.hlx.live/acrobat/online/pdf-to-word