### PR TITLE
MWPW-141293 - Regression: transparent area in widget completion stage is now white

### DIFF
--- a/acrobat/styles/styles.css
+++ b/acrobat/styles/styles.css
@@ -23,11 +23,6 @@ div[data-section="widget"] {
   min-height: 570px;
 }
 
-.DCHosted__container___3HQ1f > div:first-of-type {
-  min-height: 570px;
-  background-color: #fff;
-}
-
 /* ootb widget */
 .dc-converter-widget > div:first-of-type {
   display: none;
@@ -521,5 +516,5 @@ div.how-to ol li::before{
 @media (max-width: 600px) {
   [data-path*="caas"] .fragment {
     min-height: 1899px;
-  }  
+  }
 }


### PR DESCRIPTION
Resolves: [MWPW-141293](https://jira.corp.adobe.com/browse/MWPW-141293)

This code is moved and merged into https://git.corp.adobe.com/dc/dc-pdfverbs-web/pull/4142

Test URLs:

Before: https://main--dc--adobecom.hlx.live/acrobat/online/pdf-editor?martech=off
After: https://mwpw-141293--dc--adobecom.hlx.live/acrobat/online/pdf-editor?martech=off&app!versions=latest 