### PR TITLE
MWPW-141685 - Fallback Redirection for Unsupported URLs

### DIFF
--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -13,14 +13,14 @@ var routes = [
     }
   },
   {
-    pattern: /^\/([^\/]+)\/acrobat(?:\.html)?\/?$/,
+    pattern: /^\/([^\/]+)\/(acrobat|sign)\/.*$/,
     redirect: function(matches) {
       var locale = matches[1];
       return 'https://helpx.adobe.com/' + locale + '/x-productkb/global/adobe-supported-browsers.html';
     }
   },
   {
-    pattern: /\/acrobat\/.*/,
+    pattern: /^.*?\/(acrobat|sign)\/?(?:\.html)?$/,
     redirect: function() {
       return 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html';
     }

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -1,33 +1,17 @@
 /* eslint-disable */
+(function() {
+  var routes = [
+    { pattern: /^\/acrobat\/online\/.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' },
+    { pattern: /.*/, redirect: 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html' }
+  ];
 
-var routes = [
-  { pattern: /^\/acrobat\/online\/.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' },
-  { pattern: /.*/, redirect: 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html' }
-];
+  window.getRedirectURL = function(currentPath) {
+    var route = routes.find(r => r.pattern.test(currentPath));
+    return route ? route.redirect : null;
+  };
 
-export function getRedirectURL(currentPath) {
-  if (currentPath == null) {
-    return null;
-  }
-
-  for (var i = 0; i < routes.length; i++) {
-    if (routes[i].pattern.test(currentPath)) {
-      console.log('Redirecting to: ' + currentPath);
-      return routes[i].redirect;
-    }
-  }
-  return null;
-}
-
-export function redirectToURL(url) {
-  window.location.href = url;
-}
-
-function initiateRedirect() {
-  if (pathname = getRedirectURL(window.location.pathname)) {
-    redirectToURL(pathname);
-  }
-}
-
-window.onload = initiateRedirect;
+  window.redirectToURL = function(url) {
+    window.location.href = url;
+  };
+})();
 /* eslint-enable */

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -31,6 +31,7 @@ var routes = [
 ];
 
 window.redirectToSupportPage = function() {
+  console.log('redirectToSupportPage');
   var currentPathname = window.location.pathname;
 
   for (var i = 0; i < routes.length; i++) {
@@ -43,5 +44,5 @@ window.redirectToSupportPage = function() {
   }
 };
 
-window.redirectToSupportPage();
+redirectToSupportPage();
 /* eslint-enable */

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -13,5 +13,8 @@
   window.redirectToURL = function(url) {
     window.location.href = url;
   };
+
+  window.redirectToURL(window.getRedirectURL(window.location.pathname));
+
 })();
 /* eslint-enable */

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -1,21 +1,18 @@
 /* eslint-disable */
-(function() {
-  var routes = [
-    { pattern: /^\/acrobat\/online\/.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' },
-    { pattern: /.*/, redirect: 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html' }
-  ];
-  alert('fallback.js')
+var routes = [
+  { pattern: /^\/acrobat\/online\/.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' },
+  { pattern: /.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' }
+];
 
-  window.getRedirectURL = function(currentPath) {
-    var route = routes.find(r => r.pattern.test(currentPath));
-    return route ? route.redirect : null;
-  };
+var redirectToSupportPage = function() {
+  var currentPathname = window.location.pathname;
+  for (var i = 0; i < routes.length; i++) {
+    if (routes[i].pattern.test(currentPathname)) {
+      window.location.href = routes[i].redirect;
+      break;
+    }
+  }
+};
 
-  window.redirectToURL = function(url) {
-    window.location.href = url;
-  };
-
-  window.redirectToURL(window.getRedirectURL(window.location.pathname));
-
-})();
+redirectToSupportPage();
 /* eslint-enable */

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 var routes = [
   {
-    pattern: /^\/([a-zA-Z]{2}(?:-[a-zA-Z]{2})?)\/acrobat\/online\/.*/,
+    pattern: /^\/([^\/]+)\/acrobat\/online\/.*$/,
     redirect: function() {
       return 'https://acrobat.adobe.com/home/index-browser-eol.html';
     }
@@ -13,18 +13,14 @@ var routes = [
     }
   },
   {
-    pattern: /^\/([a-zA-Z]{2}(?:-[a-zA-Z]{2})?)\/(.*)/,
+    pattern: /^\/([^\/]+)\/acrobat(?:\.html)?\/?$/,
     redirect: function(matches) {
       var locale = matches[1];
-      if (locale === 'acrobat' || locale === 'sign') {
-        return 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html';
-      } else {
-        return 'https://helpx.adobe.com/' + locale + '/x-productkb/global/adobe-supported-browsers.html';
-      }
-      }
+      return 'https://helpx.adobe.com/' + locale + '/x-productkb/global/adobe-supported-browsers.html';
+    }
   },
   {
-    pattern: /.*/,
+    pattern: /\/acrobat\/.*/,
     redirect: function() {
       return 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html';
     }

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -4,6 +4,7 @@
     { pattern: /^\/acrobat\/online\/.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' },
     { pattern: /.*/, redirect: 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html' }
   ];
+  alert('fallback.js')
 
   window.getRedirectURL = function(currentPath) {
     var route = routes.find(r => r.pattern.test(currentPath));

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -16,9 +16,12 @@ var routes = [
     pattern: /^\/([a-zA-Z]{2}(?:-[a-zA-Z]{2})?)\/(.*)/,
     redirect: function(matches) {
       var locale = matches[1];
-      var path = matches[2];
-      return 'https://helpx.adobe.com/' + locale + '/x-productkb/global/adobe-supported-browsers.html';
-    }
+      if (locale === 'acrobat' || locale === 'sign') {
+        return 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html';
+      } else {
+        return 'https://helpx.adobe.com/' + locale + '/x-productkb/global/adobe-supported-browsers.html';
+      }
+      }
   },
   {
     pattern: /.*/,

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -1,26 +1,26 @@
 /* eslint-disable */
 var routes = [
   {
-    pattern: /^\/([^\/]+)\/acrobat\/online\/.*$/,
+    pattern: /^\/([^\/]+)\/acrobat\/online(\/.*|\.html)?$/,
     redirect: function() {
       return 'https://acrobat.adobe.com/home/index-browser-eol.html';
     }
   },
   {
-    pattern: /^\/acrobat\/online\/.*/,
+    pattern: /^\/acrobat\/online(\/.*|\.html)?$/,
     redirect: function() {
       return 'https://acrobat.adobe.com/home/index-browser-eol.html';
     }
   },
   {
-    pattern: /^\/([^\/]+)\/(acrobat|sign)\/.*$/,
+    pattern: /^\/([^\/]+)\/(acrobat|sign)(\/.*|\.html)?$/,
     redirect: function(matches) {
       var locale = matches[1];
       return 'https://helpx.adobe.com/' + locale + '/x-productkb/global/adobe-supported-browsers.html';
     }
   },
   {
-    pattern: /^.*?\/(acrobat|sign)\/?(?:\.html)?$/,
+    pattern: /^\/(acrobat|sign)(\/.*|\.html)?$/,
     redirect: function() {
       return 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html';
     }

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -1,18 +1,33 @@
 /* eslint-disable */
+
 var routes = [
   { pattern: /^\/acrobat\/online\/.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' },
-  { pattern: /.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' }
+  { pattern: /.*/, redirect: 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html' }
 ];
 
-var redirectToSupportPage = function() {
-  var currentPathname = window.location.pathname;
+export function getRedirectURL(currentPath) {
+  if (currentPath == null) {
+    return null;
+  }
+
   for (var i = 0; i < routes.length; i++) {
-    if (routes[i].pattern.test(currentPathname)) {
-      window.location.href = routes[i].redirect;
-      break;
+    if (routes[i].pattern.test(currentPath)) {
+      console.log('Redirecting to: ' + currentPath);
+      return routes[i].redirect;
     }
   }
-};
+  return null;
+}
 
-redirectToSupportPage();
+export function redirectToURL(url) {
+  window.location.href = url;
+}
+
+function initiateRedirect() {
+  if (pathname = getRedirectURL(window.location.pathname)) {
+    redirectToURL(pathname);
+  }
+}
+
+window.onload = initiateRedirect;
 /* eslint-enable */

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -1,18 +1,47 @@
 /* eslint-disable */
 var routes = [
-  { pattern: /^\/acrobat\/online\/.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' },
-  { pattern: /.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' }
+  {
+    pattern: /^\/([a-zA-Z]{2}(?:-[a-zA-Z]{2})?)\/acrobat\/online\/.*/,
+    redirect: function(matches) {
+      var locale = matches[1];
+      return 'https://acrobat.adobe.com/' + locale + '/home/index-browser-eol.html';
+    }
+  },
+  {
+    pattern: /^\/acrobat\/online\/.*/,
+    redirect: function() {
+      return 'https://acrobat.adobe.com/home/index-browser-eol.html';
+    }
+  },
+  {
+    pattern: /^\/([a-zA-Z]{2}(?:-[a-zA-Z]{2})?)\/(.*)/,
+    redirect: function(matches) {
+      var locale = matches[1];
+      var path = matches[2];
+      // Redirect to a general page with the locale
+      return 'https://helpx.adobe.com/' + locale + '/x-productkb/global/adobe-supported-browsers.html';
+    }
+  },
+  {
+    pattern: /.*/,
+    redirect: function() {
+      return 'https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html';
+    }
+  }
 ];
 
-var redirectToSupportPage = function() {
+window.redirectToSupportPage = function() {
   var currentPathname = window.location.pathname;
+
   for (var i = 0; i < routes.length; i++) {
-    if (routes[i].pattern.test(currentPathname)) {
-      window.location.href = routes[i].redirect;
+    var match = currentPathname.match(routes[i].pattern);
+    if (match) {
+      var redirectUrl = routes[i].redirect(match);
+      window.location.href = redirectUrl;
       break;
     }
   }
 };
 
-redirectToSupportPage();
+window.redirectToSupportPage();
 /* eslint-enable */

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -2,9 +2,8 @@
 var routes = [
   {
     pattern: /^\/([a-zA-Z]{2}(?:-[a-zA-Z]{2})?)\/acrobat\/online\/.*/,
-    redirect: function(matches) {
-      var locale = matches[1];
-      return 'https://acrobat.adobe.com/' + locale + '/home/index-browser-eol.html';
+    redirect: function() {
+      return 'https://acrobat.adobe.com/home/index-browser-eol.html';
     }
   },
   {

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -1,0 +1,18 @@
+/* eslint-disable */
+var routes = [
+  { pattern: /^\/acrobat\/online\/.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' },
+  { pattern: /.*/, redirect: 'https://acrobat.adobe.com/home/index-browser-eol.html' }
+];
+
+var redirectToSupportPage = function() {
+  var currentPathname = window.location.pathname;
+  for (var i = 0; i < routes.length; i++) {
+    if (routes[i].pattern.test(currentPathname)) {
+      window.location.href = routes[i].redirect;
+      break;
+    }
+  }
+};
+
+redirectToSupportPage();
+/* eslint-enable */

--- a/acrobat/scripts/fallback.js
+++ b/acrobat/scripts/fallback.js
@@ -18,7 +18,6 @@ var routes = [
     redirect: function(matches) {
       var locale = matches[1];
       var path = matches[2];
-      // Redirect to a general page with the locale
       return 'https://helpx.adobe.com/' + locale + '/x-productkb/global/adobe-supported-browsers.html';
     }
   },
@@ -30,10 +29,8 @@ var routes = [
   }
 ];
 
-window.redirectToSupportPage = function() {
-  console.log('redirectToSupportPage');
+var redirectToSupportPage = function() {
   var currentPathname = window.location.pathname;
-
   for (var i = 0; i < routes.length; i++) {
     var match = currentPathname.match(routes[i].pattern);
     if (match) {
@@ -43,6 +40,8 @@ window.redirectToSupportPage = function() {
     }
   }
 };
+window.routes = routes;
+window.redirectToSupportPage = redirectToSupportPage;
 
-redirectToSupportPage();
+window.redirectToSupportPage();
 /* eslint-enable */

--- a/head.html
+++ b/head.html
@@ -4,9 +4,3 @@
 <style>body { display: none; }</style>
 <link rel="icon" href="data:,">
 <script nomodule src="/acrobat/scripts/fallback.js"></script>
-<!-- To ensure IE redirects -->
-<script type="text/javascript">
-  if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
-    document.write('<script src="/acrobat/scripts/legacy.js"><\/script>');
-  }
-</script>

--- a/head.html
+++ b/head.html
@@ -9,3 +9,4 @@
     document.write('<script src="/acrobat/scripts/legacy.js"><\/script>');
   }
 </script>
+<script src="/acrobat/scripts/fallback.js" type="nomodule"></script>

--- a/head.html
+++ b/head.html
@@ -1,11 +1,12 @@
-<script type="module">
-  // This will only run in browsers that support ES6 modules
-  alert('ES6 Module supported!');
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://acrobat.adobe.com" crossorigin>
+<script src="/acrobat/scripts/scripts.js" type="module"></script>
+<style>body { display: none; }</style>
+<link rel="icon" href="data:,">
+<!-- To ensure IE redirects -->
+<script type="text/javascript">
+  if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
+    document.write('<script src="/acrobat/scripts/legacy.js"><\/script>');
+  }
 </script>
-
-<!-- Fallback Script -->
-<script nomodule>
-  // This will only run in browsers that DO NOT support ES6 modules
-  alert('ES6 Module NOT supported. Redirecting...');
-</script>
-<!-- <script src="/acrobat/scripts/fallback.js" nomodule></script> -->
+<script src="/acrobat/scripts/fallback.js" nomodule></script>

--- a/head.html
+++ b/head.html
@@ -3,10 +3,10 @@
 <script src="/acrobat/scripts/scripts.js" type="module"></script>
 <style>body { display: none; }</style>
 <link rel="icon" href="data:,">
+<script nomodule src="/acrobat/scripts/fallback.js"></script>
 <!-- To ensure IE redirects -->
 <script type="text/javascript">
   if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
     document.write('<script src="/acrobat/scripts/legacy.js"><\/script>');
   }
 </script>
-<script src="/acrobat/scripts/fallback.js" nomodule></script>

--- a/head.html
+++ b/head.html
@@ -9,4 +9,4 @@
     document.write('<script src="/acrobat/scripts/legacy.js"><\/script>');
   }
 </script>
-<script src="/acrobat/scripts/fallback.js" type="nomodule"></script>
+<script src="/acrobat/scripts/fallback.js" nomodule></script>

--- a/head.html
+++ b/head.html
@@ -1,12 +1,11 @@
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<link rel="preconnect" href="https://acrobat.adobe.com" crossorigin>
-<script src="/acrobat/scripts/scripts.js" type="module"></script>
-<style>body { display: none; }</style>
-<link rel="icon" href="data:,">
-<!-- To ensure IE redirects -->
-<script type="text/javascript">
-  if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
-    document.write('<script src="/acrobat/scripts/legacy.js"><\/script>');
-  }
+<script type="module">
+  // This will only run in browsers that support ES6 modules
+  alert('ES6 Module supported!');
 </script>
-<script src="/acrobat/scripts/fallback.js" nomodule></script>
+
+<!-- Fallback Script -->
+<script nomodule>
+  // This will only run in browsers that DO NOT support ES6 modules
+  alert('ES6 Module NOT supported. Redirecting...');
+</script>
+<!-- <script src="/acrobat/scripts/fallback.js" nomodule></script> -->

--- a/test/scripts/fallback.test.js
+++ b/test/scripts/fallback.test.js
@@ -1,0 +1,19 @@
+import { expect } from '@esm-bundle/chai';
+import { getRedirectURL } from '../../acrobat/scripts/fallback.js';
+
+describe('Fallback Function Tests', () => {
+  describe('getRedirectURL', () => {
+    it('should redirect frictionless paths', () => {
+      const acrobatPath = '/acrobat/online/compress-pdf';
+      expect(getRedirectURL(acrobatPath)).to.equal('https://acrobat.adobe.com/home/index-browser-eol.html');
+    });
+    it('should redirect all other paths', () => {
+      const otherPath = '/acrobat/resources/faq';
+      expect(getRedirectURL(otherPath)).to.equal('https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html');
+    });
+    it('should return null for an undefined or null path', () => {
+      expect(getRedirectURL(undefined)).to.be.null;
+      expect(getRedirectURL(null)).to.be.null;
+    });
+  });
+});

--- a/test/scripts/fallback.test.js
+++ b/test/scripts/fallback.test.js
@@ -4,5 +4,8 @@ describe('legacy test', () => {
   it('redirectToURL is assigned', async () => {
     await import('../../acrobat/scripts/fallback.js');
     expect(window.redirectToSupportPage).to.be.an('function');
+    expect(window.routes).to.be.an('array');
+    expect(window.routes[0].redirect).to.be.an('function');
+    expect(window.routes[1].redirect).to.be.an('function');
   });
 });

--- a/test/scripts/fallback.test.js
+++ b/test/scripts/fallback.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 
 describe('legacy test', () => {
-  it('window.browser is assigned', async () => {
+  it('redirectToURL is assigned', async () => {
     await import('../../acrobat/scripts/fallback.js');
-    expect(window).to.be.an('object');
+    expect(window.redirectToURL).to.be.an('function');
   });
 });

--- a/test/scripts/fallback.test.js
+++ b/test/scripts/fallback.test.js
@@ -1,19 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { getRedirectURL } from '../../acrobat/scripts/fallback.js';
 
-describe('Fallback Function Tests', () => {
-  describe('getRedirectURL', () => {
-    it('should redirect frictionless paths', () => {
-      const acrobatPath = '/acrobat/online/compress-pdf';
-      expect(getRedirectURL(acrobatPath)).to.equal('https://acrobat.adobe.com/home/index-browser-eol.html');
-    });
-    it('should redirect all other paths', () => {
-      const otherPath = '/acrobat/resources/faq';
-      expect(getRedirectURL(otherPath)).to.equal('https://helpx.adobe.com/x-productkb/global/adobe-supported-browsers.html');
-    });
-    it('should return null for an undefined or null path', () => {
-      expect(getRedirectURL(undefined)).to.be.null;
-      expect(getRedirectURL(null)).to.be.null;
-    });
+describe('legacy test', () => {
+  it('window.browser is assigned', async () => {
+    await import('../../acrobat/scripts/fallback.js');
+    expect(window).to.be.an('object');
   });
 });

--- a/test/scripts/fallback.test.js
+++ b/test/scripts/fallback.test.js
@@ -3,6 +3,6 @@ import { expect } from '@esm-bundle/chai';
 describe('legacy test', () => {
   it('redirectToURL is assigned', async () => {
     await import('../../acrobat/scripts/fallback.js');
-    expect(window.redirectToURL).to.be.an('function');
+    expect(window.redirectToSupportPage).to.be.an('function');
   });
 });

--- a/test/scripts/fallback.test.js
+++ b/test/scripts/fallback.test.js
@@ -5,7 +5,5 @@ describe('legacy test', () => {
     await import('../../acrobat/scripts/fallback.js');
     expect(window.redirectToSupportPage).to.be.an('function');
     expect(window.routes).to.be.an('array');
-    expect(window.routes[0].redirect).to.be.an('function');
-    expect(window.routes[1].redirect).to.be.an('function');
   });
 });


### PR DESCRIPTION
MWPW-141685: Adds a browser fallback mechanism to redirect users on unsupported browser paths.

This update is ensuring that visitors on unsupported browsers are guided to the right information or support pages.


**Highlights:**

- **Dynamic Redirection:** Automatically redirects users to a specific Adobe Acrobat end-of-life page or a general Adobe support page, depending on their accessed URL.
- **Pattern Matching:** Employs regular expressions to match and handle different URL paths for redirection.

Resolves: [MWPW-141685](https://jira.corp.adobe.com/browse/MWPW-141685)

Test URLs:

Before: https://main--dc--adobecom.hlx.live/acrobat/resources/benefits-of-digital-notes-for-students?martech=off
After: https://mwpw-141685--dc--adobecom.hlx.live/acrobat/resources/benefits-of-digital-notes-for-students?martech=off

Before: https://main--dc--adobecom.hlx.live/acrobat/online/compress-pdf?martech=off
After: https://mwpw-141685--dc--adobecom.hlx.live/acrobat/online/compress-pdf?martech=off
