### PR TITLE
Test EdgeWorker deployment on Acom stage

### DIFF
--- a/edgeworkers/Acrobat_DC_web_prod/bundle.json
+++ b/edgeworkers/Acrobat_DC_web_prod/bundle.json
@@ -1,4 +1,4 @@
 {
-    "edgeworker-version": "0.83",
-    "description" : "remove hash for legacy.js IE/Trident script"
+    "edgeworker-version": "0.84",
+    "description" : "Test stage deployment"
 }


### PR DESCRIPTION
- The workflow will use prod.js and stage.js from `acrobat/scripts/contentSecurityPolicy/`
- The bundle version is for Acrobat_DC_web_stage. Still finding a solution for managing both prod and stage bundle versions.