### PR TITLE
Fix E2E tests

### DIFF
--- a/test/e2e/features/regression/converter.feature
+++ b/test/e2e/features/regression/converter.feature
@@ -22,6 +22,7 @@ Feature: Frictionless Converter Block
       | add-pages-to-pdf  | test-files/test.pdf  |
       | extract-pdf-pages | test-files/test2.pdf |
       | pdf-editor        | test-files/test.pdf  |
+      | sign-pdf          | test-files/test.pdf  |
 
   @MWPW-124781 @regression @converter
   Scenario Outline: L2 Verbs - Upload and download
@@ -96,25 +97,6 @@ Feature: Frictionless Converter Block
   Examples:
       | Verb       | Files                                    |
       | rotate-pdf | test-files/test.pdf,test-files/test2.pdf |
-
-  @MWPW-137251 @regression @converter
-  Scenario Outline: L2 Verbs - Upload and sign in
-    Given I go to the <Verb> page
-     Then I upload the file "<File>"
-     Then I click "Add signature"
-     Then I fill up signature input
-     Then I click "Add initials"
-     Then I fill up signature input
-     Then I click "Add signature"
-     Then I sign up the document
-     Then I should see signature
-     Then I click "Add initials"
-     Then I sign up the document
-     Then I should see initials
-
-  Examples:
-      | Verb     | File                |
-      | sign-pdf | test-files/test.pdf |
 
   @MWPW-127633 @regression @converter @signedin
   Scenario Outline: L1 Verbs - Redirects for signed-in visitors

--- a/test/e2e/features/regression/converter.feature
+++ b/test/e2e/features/regression/converter.feature
@@ -111,8 +111,6 @@ Feature: Frictionless Converter Block
      Then I click "Add initials"
      Then I sign up the document
      Then I should see initials
-     Then I wait for 2 seconds
-     Then I click "Sign in to download"
 
   Examples:
       | Verb     | File                |

--- a/test/e2e/features/regression/eventwrapper.feature
+++ b/test/e2e/features/regression/eventwrapper.feature
@@ -103,12 +103,6 @@ Feature: Frictionless Event Wrapper Block
       Then I should not see eventwrapper onload
       Then I should not see the review component
       Then I should not see the verb subfooter
-      Then I click "Sign in to download"
-      Then I wait for 2 seconds
-      Then I should see sign-in modal
-      Then I should not see eventwrapper onload
-      Then I should not see the review component
-      Then I should not see the verb subfooter
 
   Examples:
       | Verb     | File                |

--- a/test/e2e/features/regression/eventwrapper.feature
+++ b/test/e2e/features/regression/eventwrapper.feature
@@ -93,21 +93,6 @@ Feature: Frictionless Event Wrapper Block
       | Verb       | File                |
       | rotate-pdf | test-files/test.pdf |
 
-  @MWPW-137439 @regression @eventwrapper
-  Scenario Outline: L2 Verbs - Personalization events for sign-pdf
-      Given I go to the <Verb> page
-      Then I should see eventwrapper onload
-      Then I should see the review component
-      Then I should see the verb subfooter
-      Then I upload the file "<File>"
-      Then I should not see eventwrapper onload
-      Then I should not see the review component
-      Then I should not see the verb subfooter
-
-  Examples:
-      | Verb     | File                |
-      | sign-pdf | test-files/test.pdf |
-
   @MWPW-138330 @regression @eventwrapper
   Scenario Outline: L2 Verbs - Personalization events for password-protect-pdf
      Given I go to the <Verb> page

--- a/test/e2e/step-definitions/dc.steps.js
+++ b/test/e2e/step-definitions/dc.steps.js
@@ -535,7 +535,7 @@ Then(/^I should see the footer promo elements$/, async function () {
   await expect(this.page.footerPromoBullets).toBeVisible({timeout: 5000});
 });
 
-Then(/^I should see that the prices match on checkout from the (.*) merch card(?:|s)$/, async function (items) {
+Then(/^I should see that the prices match on checkout from the (.*) merch card(?:|s)$/, {timeout: 120000}, async function (items) {
   this.context(DCPage);
 
   let products = items.replace(/ and /g, ";").split(';');


### PR DESCRIPTION
- Sign PDF is changed to L1. Remove Sign PDF test cases and add it to L1.
- Pricing checking step may take longer than 1 min
- Test cases MWPW-137251 and MWPW-137439 are set inactive in Jira.