### PR TITLE
MWPW-143709 Auto trigger Akamai cache purge

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,6 +1,17 @@
 name: Clear Akamai Cache
 
 on:
+  workflow_call:
+    inputs:
+      cpCode:
+        description: 'CP Code'
+        required: true
+        type: string
+      network:
+        description: 'Network'
+        required: true
+        type: string
+
   workflow_dispatch:
     inputs:
       cpCode:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - stage
+
+jobs:
+  clear-stage-cache:
+    if: github.ref == 'refs/heads/stage'
+    uses: ./.github/workflows/clear-cache.yml
+    with:
+      cpCode: 1551833
+      network: production
+    secrets: inherit
+
+  clear-prod-cache:
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/clear-cache.yml
+    with:
+      cpCode: 1551836
+      network: production
+    secrets: inherit


### PR DESCRIPTION
- Create a release workflow. Put purging Akamai cache there. In the future, release notes or release related tasks can be added.
- It purges Akamai cache only when there is a push to `main` or `stage`. Still researching when purging cache is needed for metadata update.

Test URL:
 N/A 