### PR TITLE
MWPW-147215: PDF inline SDK viewer envs

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -251,16 +251,12 @@ const CONFIG = {
     pdfViewerClientId: 'ec572982b2a849d4b16c47d9558d66d1',
     pdfViewerReportSuite: 'adbadobedxqa',
   },
-  dcmain: {
+  page: {
     pdfViewerClientId: 'a42d91c0e5ec46f982d2da0846d9f7d0',
     pdfViewerReportSuite: 'adbadobedxqa',
   },
-  dcstage: {
+  stagePage: {
     pdfViewerClientId: '2522674a708e4ddf8bbd62e18585ae4b',
-    pdfViewerReportSuite: 'adbadobedxqa',
-  },
-    page: {
-    pdfViewerClientId: 'a42d91c0e5ec46f982d2da0846d9f7d0',
     pdfViewerReportSuite: 'adbadobedxqa',
   },
   stage: {


### PR DESCRIPTION
Resolves: [MWPW-147215](https://jira.corp.adobe.com/browse/MWPW-147215)

Enables PDF SDK viewer base on the env we want it to test using a query string to set the proper env to test via query string

env=page for test main under hlx.page
env=stagePage for test stage under hlx.page

After merge we should be able to test it:

- https://main--dc--adobecom.hlx.page/acrobat/business/reports/sdk/adobe-acrobat-microsoft-365-brief?env=page
- https://stage--dc--adobecom.hlx.page/acrobat/business/reports/sdk/adobe-acrobat-microsoft-365-brief?env=stagePage
- https://mwpw-147215--dc--adobecom.hlx.page/