### PR TITLE
MWPW-149225: DC Interactive Marquee Tracking attributes for analytics

### DIFF
--- a/acrobat/blocks/interactive-marquee/interactive-marquee.js
+++ b/acrobat/blocks/interactive-marquee/interactive-marquee.js
@@ -119,6 +119,7 @@ function createTab(slide, index, isFirst) {
     'data-index': index,
     'aria-selected': isFirst ? 'true' : 'false',
     'aria-labelledby': `Viewing ${slide.label}`,
+    'daa-ll': `btn-${index + 1}`,
   }, slide.icon);
 
   const tabLabel = createTag('p', { class: 'slider-label' }, slide.label);
@@ -138,6 +139,8 @@ function createSlideComponents(slides) {
   const tabs = createTag('ul', { class: 'slider-tabs', role: 'tablist' });
   const deck = createTag('div', { class: 'slider-deck' });
   let firstSlideActive = true;
+  // track the index of the slide
+  tabs.setAttribute('daa-lh', 'marquee-nav');
 
   slides.forEach((slide, index) => {
     const tab = createTab(slide, index, firstSlideActive);


### PR DESCRIPTION
Resolves: [MWPW-149225](https://jira.corp.adobe.com/browse/MWPW-149225)

Adds specific attributes to track clicks under marquee navigation when user switch between videos

`daa-lh="marquee-nav"` and `daa-lh="btn-{1,2,3}"`

Test url: 

Before: https://main--dc--adobecom.hlx.page/drafts/rivero/MWPW-148327/interactive-marquee
After: https://mwpw-149225--dc--adobecom.hlx.page/drafts/rivero/MWPW-148327/interactive-marquee