### PR TITLE
MWPW-146848: Repo Sync checkout action version update

### DIFF
--- a/.github/workflows/fg-sync-repos.yml
+++ b/.github/workflows/fg-sync-repos.yml
@@ -26,7 +26,7 @@ jobs:
           repositories: "dc-pink"
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           ref: ${{ inputs.syncBranch }}


### PR DESCRIPTION
Checkout Action v2 seems to be working for milo, bacom and cc. But fails on dc for some reason.
Upgrading to v3 and testing with a temp dc clone repo seems to have worked.