### PR TITLE
[MWPW 151457] Added stage domains map to make links environment-aware

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -278,6 +278,14 @@ const CONFIG = {
   locales,
   // geoRouting: 'on',
   prodDomains: ['www.adobe.com', 'business.adobe.com', 'helpx.adobe.com'],
+  stageDomainsMap: {
+    'www.adobe.com': 'www.stage.adobe.com',
+    'business.adobe.com': 'business.stage.adobe.com',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'blog.adobe.com': 'blog.stage.adobe.com',
+    'developer.adobe.com': 'developer-stage.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+  },
   jarvis: {
     id: 'DocumentCloudWeb1',
     version: '1.0',


### PR DESCRIPTION
**Description**
This PR adds the `stageDomainsMap` to the config allowing links to be environment-aware.
More about this new feature can be found in [here](https://github.com/orgs/adobecom/discussions/2437).

Resolves: [MWPW-151457](https://jira.corp.adobe.com/browse/MWPW-151457)