### PR TITLE
MWPW-153563 Make loadLCPImage smarter

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -342,9 +342,14 @@ replaceDotMedia(document);
 
 // Default to loading the first image as eager.
 (async function loadLCPImage() {
-  const index = window.browser.isMobile ? 1 : 3;
-  const selector = `.marquee:not(.small) > div > div:nth-of-type(${index}) img, .marquee.small img`;
-  document.querySelector(selector)?.setAttribute('loading', 'eager');
+  const marquee = document.querySelector('.marquee'); // first marquee only
+  if (marquee) {
+    const index = window.browser.isMobile ? 1 : 3;
+    const selectorBG = `.marquee > div:nth-child(1) > div:nth-of-type(${index}) img`;
+    const selectorFG = '.marquee > div:nth-child(2) img';
+    marquee.querySelector(selectorBG)?.setAttribute('loading', 'eager');
+    marquee.querySelector(selectorFG)?.setAttribute('loading', 'eager');
+  }
 }());
 
 /*

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -342,8 +342,9 @@ replaceDotMedia(document);
 
 // Default to loading the first image as eager.
 (async function loadLCPImage() {
-  const lcpImg = document.querySelector('img');
-  lcpImg?.setAttribute('loading', 'eager');
+  const index = window.browser.isMobile ? 1 : 3;
+  const selector = `.marquee:not(.small) > div > div:nth-of-type(${index}) img, .marquee.small img`;
+  document.querySelector(selector)?.setAttribute('loading', 'eager');
 }());
 
 /*


### PR DESCRIPTION
Put eager loading on the image in a `marquee` and `marquee small`.

Resolves: [MWPW-153563](https://jira.corp.adobe.com/browse/MWPW-153563)

**Test URLs**
Before:
https://main--dc--adobecom.hlx.live/acrobat/how-to/pdf-editor-pdf-files  (marquee)
https://main--dc--adobecom.hlx.live/acrobat/business/resources  (marquee small)
https://main--dc--adobecom.hlx.live/acrobat/online/word-to-pdf  (no marquee)

After:
https://mwpw-153563--dc--adobecom.hlx.live/acrobat/how-to/pdf-editor-pdf-files  (marquee)
https://mwpw-153563--dc--adobecom.hlx.live/acrobat/business/resources (marquee small)
https://mwpw-153563--dc--adobecom.hlx.live/acrobat/online/word-to-pdf  (no marquee)