### PR TITLE
MWPW-155429: Removed www.adobe.com from stagedomains map

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -294,7 +294,6 @@ const CONFIG = {
   // geoRouting: 'on',
   prodDomains: ['www.adobe.com', 'business.adobe.com', 'helpx.adobe.com'],
   stageDomainsMap: {
-    'www.adobe.com': 'www.stage.adobe.com',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',


### PR DESCRIPTION
Resolves: [MWPW-155429](https://jira.corp.adobe.com/browse/MWPW-155429)

Test URL: https://mwpw-155429--dc--adobecom.hlx.page/