### PR TITLE
kick off async loading of IMS before awaiting loadArea

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -461,19 +461,19 @@ const { ietf } = getLocale(locales);
   }
 
   setConfig({ ...CONFIG, miloLibs });
-  loadLana({ clientId: 'dxdc', tags: 'DC_Milo' });
 
-  // get event back form dc web and then load area
-  await loadArea(document, false);
-  // Setup Logging
-  const { default: lanaLogging } = await import('./dcLana.js');
-  lanaLogging();
-
-  // IMS Ready
   loadIms().then(() => {
     const imsIsReady = new CustomEvent('IMS:Ready');
     window.dispatchEvent(imsIsReady);
   });
+
+  loadLana({ clientId: 'dxdc', tags: 'DC_Milo' });
+
+  await loadArea(document, false);
+
+  // Setup Logging
+  const { default: lanaLogging } = await import('./dcLana.js');
+  lanaLogging();
 
   // DC Hosted Ready...
   const dcHostedReady = setInterval(() => {


### PR DESCRIPTION
Replaces #741

Give IMS a chance to start loading sooner. IMS:Ready event was firing much later than necessary.

Test url:
https://imssoonest--dc--adobecom.hlx.page/