### PR TITLE
MWPW-160879 Add hero-marquee in loadLCPImage

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -354,11 +354,12 @@ replaceDotMedia(document);
 
 // Default to loading the first image as eager.
 (async function loadLCPImage() {
-  const marquee = document.querySelector('.marquee'); // first marquee only
+  const blocks = '.marquee,.hero-marquee';
+  const marquee = document.querySelector(blocks); // first marquee only
   if (marquee) {
     const index = window.browser.isMobile ? 1 : 3;
-    const selectorBG = `.marquee > div:nth-child(1) > div:nth-of-type(${index}) img`;
-    const selectorFG = '.marquee > div:nth-child(2) img';
+    const selectorBG = `${blocks} > div:nth-child(1) > div:nth-of-type(${index}) img`;
+    const selectorFG = `${blocks} > div:nth-child(2) img`;
     marquee.querySelector(selectorBG)?.setAttribute('loading', 'eager');
     marquee.querySelector(selectorFG)?.setAttribute('loading', 'eager');
   }


### PR DESCRIPTION
- The old code only checks `marquee` block. Some pages may use `hero-marquee`. 
- The image in a hero marquee should have the loading eager attribute.

Resolves: [MWPW-160879](https://jira.corp.adobe.com/browse/MWPW-160879)

**Test URLs**
Before : http://main--dc--adobecom.hlx.live/acrobat/features/modify-pdfs
After : http://MWPW-160879--dc--adobecom.hlx.live/acrobat/features/modify-pdfs