### PR TITLE
MWPW-164471 CC & DC Config - acom learn folder should not have .html appended

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -333,6 +333,7 @@ const CONFIG = {
   htmlExclude: [
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?learn(\/.*)?/,
   ],
   imsScope: 'AdobeID,openid,gnav,pps.read,firefly_api,additional_info.roles,read_organizations',
 };


### PR DESCRIPTION
add learn subfolder to htmlExclude
Resolves: [MWPW-164471](https://jira.corp.adobe.com/browse/MWPW-164471)

Test URLs:

Before: https://main--dc--adobecom.hlx.live/?martech=off
After: https://excludelearn--dc--adobecom.hlx.live/?martech=off

Since .html is only appended on stage and prod, you'll need to use content override for the DC utils file to test it.
Go to
https://www.adobe.com/acrobat.html?mep=/dc-shared/fragments/tests/2025/q1/excludelearn-pr/manifest.json

Look for the button in black banner after the marquee. Note the URL has a `.html`. Use content override on acrobat\scripts\scripts.js to this PRs version of the file and reload. Note there is no longer an .html appended to the button's href.