### PR TITLE
MWPW-165647: Fixed placeholder loading

### DIFF
--- a/acrobat/blocks/rnr/rnr.js
+++ b/acrobat/blocks/rnr/rnr.js
@@ -498,7 +498,7 @@ export default async function init(element) {
     window.lana?.log('Verb not configured for the rnr widget');
   }
   preloadIcons();
-  await loadPlaceholders();
+  await loadPlaceholders('rnr');
   await loadRnrData();
   initControls(element);
 }


### PR DESCRIPTION
Placeholder loading without a block option wasn't working when some placeholders had already been loaded on the page. In this PR, a new param has been implemented for the `loadPlaceholders` function, which specifies a prefix. If no placeholders have been loaded for that prefix, the loading still happens, even if some placeholders are already present. The RNR block uses the `rnr` prefix. 

Resolves: [MWPW-165647](https://jira.corp.adobe.com/browse/MWPW-165647)

Current: https://main--dc--adobecom.hlx.page/acrobat/online/word-to-pdf
Test URL: https://mwpw-165647--dc--adobecom.hlx.page/acrobat/online/word-to-pdf