### PR TITLE
MWPW-167827: RNR snapshot fix

### DIFF
--- a/test/blocks/rnr/rnr.test.js
+++ b/test/blocks/rnr/rnr.test.js
@@ -10,6 +10,7 @@ describe('rnr - Ratings and reviews', () => {
   beforeEach(async () => {
     document.head.innerHTML = await readFile({ path: './mocks/head.html' });
     document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+    localStorage.removeItem('rnr-snapshot');
     window.mph = { 'rnr-rating-tooltips': 'Poor, Below Average, Good, Very Good, Outstanding' };
     window.adobeIMS = { getAccessToken: () => {} };
     window.lana = { log: () => {} };


### PR DESCRIPTION
The `snapshot` was badly implemented, because the `localStorage` entry was common between all frictionless pages. This modifies the `rnr-snapshot` stored in `localStorage` to contain data per given verb.

Resolves: [MWPW-167827](https://jira.corp.adobe.com/browse/MWPW-167827)

Current: https://main--dc--adobecom.hlx.page/acrobat/online/word-to-pdf
Test URLs: 
- https://mwpw-167827--dc--adobecom.hlx.page/acrobat/online/word-to-pdf
- https://mwpw-167827--dc--adobecom.hlx.page/acrobat/online/jpg-to-pdf