### PR TITLE
MWPW-169531 Add aria labels to new cart buttons created by dc-merch-checkbox block

### DIFF
--- a/acrobat/blocks/dc-merch-card-checkbox/dc-merch-card-checkbox.js
+++ b/acrobat/blocks/dc-merch-card-checkbox/dc-merch-card-checkbox.js
@@ -195,6 +195,22 @@ function addReaderButton(button, md, aiOsiCodes) {
     button.setAttribute('aria-label', `${button.textContent} ${headline}`);
   }
   button.parentNode.appendChild(buyButton);
+  if (buyButton.hasAttribute('aria-label')) {
+    const newLabel = buyButton.getAttribute('aria-label').replace('Acrobat', 'AI Assistant');
+    buyButton.setAttribute('aria-label', newLabel);
+  } else {
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'aria-label') {
+          const newLabel = buyButton.getAttribute('aria-label').replace('Acrobat', 'AI Assistant');
+          buyButton.setAttribute('aria-label', newLabel);
+          observer.disconnect();
+        }
+      }
+    });
+    observer.observe(button, { attributes: true, attributeFilter: ['aria-label'] });
+  }
+
 }
 function addAriaLabel(button, newButton) {
   if (button.hasAttribute('aria-label')) {

--- a/acrobat/blocks/dc-merch-card-checkbox/dc-merch-card-checkbox.js
+++ b/acrobat/blocks/dc-merch-card-checkbox/dc-merch-card-checkbox.js
@@ -190,7 +190,26 @@ function addReaderButton(button, md, aiOsiCodes) {
   buyButton.classList.add(AI_CLASS);
   buyButton.classList.add('button-l');
   buyButton.dataset.wcsOsi = aiOsiCodes.primary;
+  if (!button.getAttribute('aria-label')) {
+    const headline = button.closest('div:has(h3)')?.querySelector('h3')?.textContent;
+    button.setAttribute('aria-label', `${button.textContent} ${headline}`);
+  }
   button.parentNode.appendChild(buyButton);
+}
+function addAriaLabel(button, newButton) {
+  if (button.hasAttribute('aria-label')) {
+    newButton.setAttribute('aria-label', `${button.getAttribute('aria-label')} with AI Assistant`);
+  } else {
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'aria-label') {
+          newButton.setAttribute('aria-label', `${button.getAttribute('aria-label')} with AI Assistant`);
+          observer.disconnect();
+        }
+      }
+    });
+    observer.observe(button, { attributes: true, attributeFilter: ['aria-label'] });
+  }
 }
 async function addButtons({ card, md, fragAudience, cardPlanType }) {
   decorateDefaultLinkAnalytics(card, getConfig());
@@ -211,6 +230,7 @@ async function addButtons({ card, md, fragAudience, cardPlanType }) {
     clonedButton.setAttribute('daa-ll', `ai-${daaLl}`);
     button.classList.add(NO_AI_CLASS);
     button.parentNode.insertBefore(clonedButton, button);
+    addAriaLabel(button, clonedButton);
     attachQtyUpdateObserver(button, clonedButton);
   });
 }


### PR DESCRIPTION
The dc-merch-card-checkbox block clones the existing buttons in merch-cards. However, the aria labels are added asynchronously and are usually not yet present at the time of cloning.  Additionally, the aria labels fails to be added to the original download button when the new cart link with AI is added next to it. This update:
1. attempts to add the aria label if it exists when cloning cart links
2. adds a mutation observer to add it later if needed
3. adds an aira label to the initial download button in reader cards

Resolves: [MWPW-169531 Add aria lables to new cart buttons created by dc-merch-checkbox block](https://jira.corp.adobe.com/browse/MWPW-169531)

To QA: Check the aria labels on the merch card buttons (with and without the checkbox selected). Both should have them.
Before 1: https://main--dc--adobecom.aem.page/acrobat
After 1: https://dc-merch-card-checkbox-aria--dc--adobecom.aem.page/acrobat

Before 2: https://main--dc--adobecom.aem.page/acrobat/pricing
After 2: https://dc-merch-card-checkbox-aria--dc--adobecom.aem.page/acrobat/pricing