### PR TITLE
MWPW-170071: Consuming limits from Verb widget block

### DIFF
--- a/acrobat/blocks/unity/unity.js
+++ b/acrobat/blocks/unity/unity.js
@@ -1,4 +1,4 @@
-import LIMITS from '../verb-widget/limits.js';
+import { LIMITS } from '../verb-widget/verb-widget.js';
 
 export const localeMap = {
   '': 'en-us',

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -46,7 +46,7 @@ const appEnvCookieMap = {
   prod: 'p_ac_',
 };
 
-const LIMITS = {
+export const LIMITS = {
   fillsign: {
     maxFileSize: 104857600, // 100 MB
     maxFileSizeFriendly: '100 MB', // 100 MB


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Consuming limits from verb widget since is preloaded, and removing limits.js dependency 
## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-170071](https://jira.corp.adobe.com/browse/MWPW-170071)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.aem.page/acrobat/online/sign-pdf
- http://mwpw-170071--dc--adobecom.aem.page/acrobat/online/sign-pdf