### PR TITLE
MWPW-170003: How To pages lazy loading

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -403,11 +403,8 @@ replaceDotMedia(document);
   const blocks = '.marquee,.hero-marquee';
   const marquee = document.querySelector(blocks); // first marquee only
   if (marquee) {
-    const index = window.browser.isMobile ? 1 : 3;
-    const selectorBG = `${blocks} > div:nth-child(1) > div:nth-of-type(${index}) img`;
-    const selectorFG = `${blocks} > div:nth-child(2) img`;
-    marquee.querySelector(selectorBG)?.setAttribute('loading', 'eager');
-    marquee.querySelector(selectorFG)?.setAttribute('loading', 'eager');
+    const index = window.browser.isMobile ? 0 : 1;
+    marquee.querySelectorAll('img')[index]?.setAttribute('loading', 'eager');
   }
 }());
 


### PR DESCRIPTION
## Description
Update to logic that loads background image in MILO marquees (marquee and hero marquee) eagerly.
Note, foreground image is now loaded afterwards so loading eagerly makes little difference.

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-170003](https://jira.corp.adobe.com/browse/MWPW-170003)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf
- http://mwpw-170003--dc--adobecom.aem.page/acrobat/online/compress-pdf