### PR TITLE
[MWPW-169785][Unity] Workflow authoring enhancements to improve performance

### DIFF
--- a/acrobat/blocks/unity/unity.js
+++ b/acrobat/blocks/unity/unity.js
@@ -111,7 +111,8 @@ export default async function init(el) {
   }
 
   const element = el.querySelector('span');
-  const verb = element.classList[1].replace('icon-', '');
+  const verbWidget = el.closest('.section')?.querySelector('.verb-widget');
+  const verb = (verbWidget && [...verbWidget.classList].find(cn => LIMITS[cn])) || element.classList[1].replace('icon-', '');
   if (mobileApp && LIMITS[verb].mobileApp) return;
 
   const unitylibs = getUnityLibs();


### PR DESCRIPTION
## Description
This PR is a dependency for [this Unity PR](https://github.com/adobecom/unity/pull/320). This change removes the need for the icon expression used for the Unity workflow verb. Now, we’ll get the verb directly from the verb-widget block.

## Related Issue
Resolves: [MWPW-169785](https://jira.corp.adobe.com/browse/MWPW-169785)

## Test URLs
- I could not add a test URL as I don't have the permissions to push a branch on the adobecom/dc and configuring Sidekick to preview using my fork seems to not be working. 