### PR TITLE
MWPW-170387: Preloading locale specific placeholders

### DIFF
--- a/acrobat/scripts/contentSecurityPolicy/dev.js
+++ b/acrobat/scripts/contentSecurityPolicy/dev.js
@@ -215,7 +215,7 @@ const scriptSrc = [
   '*.aem.page',
   '*.aem.live',
   'tr.snapchat.com',
-  '\'sha256-ggQ3UJlEGjUjmJjLZXZyjmCbwSLYYVLQQ3S4Kyxo1GI=\'',
+  '\'sha256-/XKhgJSKy7/PtMNXm1ich1mVVa9BU4USHHVLjUnBTt4=\'',
   ';',
 ];
 

--- a/acrobat/scripts/contentSecurityPolicy/prod.js
+++ b/acrobat/scripts/contentSecurityPolicy/prod.js
@@ -260,7 +260,7 @@ const scriptSrc = [
   'rum.hlx.page',
   'tr.snapchat.com',
   'api.demandbase.com/api/v3',
-  '\'sha256-ggQ3UJlEGjUjmJjLZXZyjmCbwSLYYVLQQ3S4Kyxo1GI=\'',
+  '\'sha256-/XKhgJSKy7/PtMNXm1ich1mVVa9BU4USHHVLjUnBTt4=\'',
   ';',
 ];
 

--- a/acrobat/scripts/contentSecurityPolicy/stage.js
+++ b/acrobat/scripts/contentSecurityPolicy/stage.js
@@ -265,7 +265,7 @@ const scriptSrc = [
   's.yimg.jp',
   'yjtag.yahoo.co.jp',
   'tr.snapchat.com',
-  '\'sha256-ggQ3UJlEGjUjmJjLZXZyjmCbwSLYYVLQQ3S4Kyxo1GI=\'',
+  '\'sha256-/XKhgJSKy7/PtMNXm1ich1mVVa9BU4USHHVLjUnBTt4=\'',
   ';',
 ];
 

--- a/head.html
+++ b/head.html
@@ -24,6 +24,14 @@
     return `https://${branch}${branch.includes('--')? '' : '--unity--adobecom'}.${env}.live/unitylibs`;
   }
 
+  window.extractLocalePrefix = (pathname = window.location.pathname) => {
+    const segments = pathname.split('/').filter(Boolean);
+    if (!segments[0] || segments[0] === 'acrobat') {
+      return '';
+    }
+    return `/${segments[0]}`;
+  }
+
   window.loadLink = (href, options = {}) => {
     const { as, callback, crossorigin, rel, fetchpriority } = options;
     let link = document.head.querySelector(`link[href="${href}"]`);
@@ -47,8 +55,10 @@
 
   const miloLibs = setLibs('/libs');
   const unityLibs = getUnityLibs();
+  const localePrefix =  extractLocalePrefix();
 
-  const preloads = document.querySelector('meta[name="preloads"]')?.content?.split(',').map(x => x.trim().replace('$MILOLIBS', miloLibs).replace('$UNITYLIBS', unityLibs)) || [];
+
+  const preloads = document.querySelector('meta[name="preloads"]')?.content?.split(',').map(x => x.trim().replace('$MILOLIBS', miloLibs).replace('$UNITYLIBS', unityLibs).replace('$LOCALEPREFIX', localePrefix)) || [];
   preloads.forEach((link) => {
     if (link.endsWith('.js')) {
       loadLink(link, { as: 'script', rel: 'preload', crossorigin: 'anonymous' });


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR introduces the extractLocalePrefix() function, which extracts the locale prefix from the current window location pathname. The function returns an empty string when the path starts with /acrobat/ and returns the locale prefix (e.g., /fr, /sa_en) otherwise. This enhancement enables dynamic preloading of the locale-specific placeholders.json file, removing hardcoded paths on the metadata-eng.json

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-170387](https://jira.corp.adobe.com/browse/MWPW-170387)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.aem.page/hk_en/acrobat/online/test/sign-pdf
- http://mwpw-170387--dc--adobecom.aem.page/hk_en/acrobat/online/test/sign-pdf

<img width="2049" alt="Screenshot 2025-03-26 at 10 15 08 AM" src="https://github.com/user-attachments/assets/e6928405-e000-4e53-a6fe-c1a7883f830d" />
