### PR TITLE
Update integration-test.yml

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.testCodeBranch }}
 
       - name: Cache dependencies
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: modules-${{ hashFiles('package-lock.json') }}-${{ runner.os }}
@@ -45,7 +45,7 @@ jobs:
         
       - name: Save test logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots
           path: |


### PR DESCRIPTION
Update to the current valid actions version. Should be able to run the Integration Test after the update. Verified on https://github.com/tedAir/dc.

## Description
<!-- Provide a brief description of the changes in this PR -->
Update the download versions to the current valid ones.

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-171058](https://jira.corp.adobe.com/browse/MWPW-171058) for Integration Test. Once this works, will fix the rest of tests such as Smoke Test.

## Test URLs
<!-- List the URLs where the changes can be tested -->
- URL for testing:
- https://mwpw-171058--dc--adobecom.aem.page/