### PR TITLE
[MWPW-170827] send browser tab closure event to splunk

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -223,10 +223,17 @@ function redDir(verb) {
   window.location.href = redDirLink(verb);
 }
 
+function getSplunkEndpoint() {
+  return (getEnv() === 'prod')
+  ? 'https://unity.adobe.io/api/v1/log'
+  : 'https://unity-stage.adobe.io/api/v1/log'; 
+}
+
 let exitFlag;
 function handleExit(event, verb, userObj, unloadFlag) {
   if (exitFlag) { return; }
   window.analytics.verbAnalytics('job:browser-tab-closure', verb, userObj, unloadFlag);
+  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, userObj, getSplunkEndpoint());
   event.preventDefault();
   event.returnValue = true;
 }
@@ -815,12 +822,6 @@ export default async function init(element) {
       },
     }));
   });
-
-  function getSplunkEndpoint() {
-    return (getEnv() === 'prod')
-    ? 'https://unity.adobe.io/api/v1/log'
-    : 'https://unity-stage.adobe.io/api/v1/log'; 
-  }
 
   function handleAnalyticsEvent(eventName, metadata, documentUnloading = true, canSendDataToSplunk = true) {
     window.analytics.verbAnalytics(eventName, VERB, metadata, documentUnloading);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
We are already sending the browser tab closure events to AA. Let's also send them t our new splunk analytics.
## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-170827](https://jira.corp.adobe.com/browse/MWPW-170827)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf
- http://mwpw-XXXXXX--dc--adobecom.aem.page/acrobat/online/compress-pdf