### PR TITLE
MWPW-171714: Fix Analytics Fail to Load on Safari

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -421,7 +421,7 @@ function createSvgElement(iconName) {
 window.analytics = {
   verbAnalytics: () => {},
   reviewAnalytics: () => {},
-  sendAnalyticsToSplunk: () => {}
+  sendAnalyticsToSplunk: () => {},
 };
 
 async function loadAnalyticsAfterLCP(analyticsData) {
@@ -654,6 +654,54 @@ export default async function init(element) {
     if (accountType !== 'type1') redDir(VERB);
   }
 
+  function handleAnalyticsEvent(
+    eventName,
+    metadata,
+    documentUnloading = true,
+    canSendDataToSplunk = true,
+  ) {
+    window.analytics.verbAnalytics(eventName, VERB, metadata, documentUnloading);
+    if (!canSendDataToSplunk) return;
+    window.analytics.sendAnalyticsToSplunk(eventName, VERB, metadata, getSplunkEndpoint());
+  }
+
+  function setCookie(name, value, expires) {
+    document.cookie = `${name}=${value};domain=.adobe.com;path=/;expires=${expires}`;
+  }
+
+  function handleUploadingEvent(data, attempts, cookieExp, canSendDataToSplunk) {
+    prefetchTarget();
+    const metadata = mergeData({ ...data, userAttempts: attempts });
+    handleAnalyticsEvent('job:uploading', metadata, false, canSendDataToSplunk);
+    if (LIMITS[VERB]?.multipleFiles) {
+      handleAnalyticsEvent('job:multi-file-uploading', metadata, false, canSendDataToSplunk);
+    }
+    setCookie('UTS_Uploading', Date.now(), cookieExp);
+    window.addEventListener('beforeunload', (windowEvent) => {
+      handleExit(windowEvent, VERB, { ...data, userAttempts: attempts }, false);
+    });
+  }
+
+  function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
+    setTimeout(() => {
+      window.dispatchEvent(redirectReady);
+      window.lana?.log(
+        'Adobe Analytics done callback failed to trigger, 3 second timeout dispatched event.',
+        { sampleRate: 100, tags: 'DC_Milo,Project Unity (DC)' },
+      );
+    }, 3000);
+    setCookie('UTS_Uploaded', Date.now(), cookieExp);
+    const calcUploadedTime = uploadedTime();
+    const metadata = { ...data, uploadTime: calcUploadedTime, userAttempts: attempts };
+    handleAnalyticsEvent('job:uploaded', metadata, false, canSendDataToSplunk);
+    if (LIMITS[VERB]?.multipleFiles) {
+      handleAnalyticsEvent('job:multi-file-uploaded', metadata, false, canSendDataToSplunk);
+    }
+    exitFlag = true;
+    setUser();
+    incrementVerbKey(`${VERB}_attempts`);
+  }
+
   const { cookie } = document;
   const limitCookie = exhLimitCookieMap[VERB] || exhLimitCookieMap[VERB.match(/^pdf-to|to-pdf$/)?.[0]];
   const cookiePrefix = appEnvCookieMap[DC_ENV] || '';
@@ -748,7 +796,6 @@ export default async function init(element) {
       uploaded: () => handleUploadedEvent(data, userAttempts, cookieExp, canSendDataToSplunk),
       redirectUrl: () => {
         if (data) initiatePrefetch(data.redirectUrl);
-        const metadata = mergeData({ ...data, userAttempts });
         handleAnalyticsEvent('job:redirect-success', metadata, false, canSendDataToSplunk);
       },
     };
@@ -817,7 +864,14 @@ export default async function init(element) {
     if (key) {
       const event = errorAnalyticsMap[key];
       window.analytics.verbAnalytics(event, VERB, event === 'error' ? { errorInfo } : {});
-      if(canSendDataToSplunk) window.analytics.sendAnalyticsToSplunk(event, VERB, {...metadata, errorData}, getSplunkEndpoint());
+      if (canSendDataToSplunk) {
+        window.analytics.sendAnalyticsToSplunk(
+          event,
+          VERB,
+          { ...metadata, errorData },
+          getSplunkEndpoint(),
+        );
+      }
     }
   });
 
@@ -844,47 +898,4 @@ export default async function init(element) {
       },
     }));
   });
-
-  function handleAnalyticsEvent(eventName, metadata, documentUnloading = true, canSendDataToSplunk = true) {
-    window.analytics.verbAnalytics(eventName, VERB, metadata, documentUnloading);
-    if(!canSendDataToSplunk)  return;
-    window.analytics.sendAnalyticsToSplunk(eventName, VERB, metadata, getSplunkEndpoint());
-  }
-
-  function setCookie(name, value, expires) {
-    document.cookie = `${name}=${value};domain=.adobe.com;path=/;expires=${expires}`;
-  }
-
-  function handleUploadingEvent(data, userAttempts, cookieExp, canSendDataToSplunk) {
-    prefetchTarget();
-    const metadata = mergeData({ ...data, userAttempts });
-    handleAnalyticsEvent('job:uploading', metadata, false, canSendDataToSplunk);
-    if (LIMITS[VERB]?.multipleFiles) {
-      handleAnalyticsEvent('job:multi-file-uploading', metadata, false, canSendDataToSplunk);
-    }
-    setCookie('UTS_Uploading', Date.now(), cookieExp);
-    window.addEventListener('beforeunload', (windowEvent) => {
-      handleExit(windowEvent, VERB, { ...data, userAttempts }, false);
-    });
-  }
-
-  function handleUploadedEvent(data, userAttempts, cookieExp, canSendDataToSplunk) {
-    setTimeout(() => {
-      window.dispatchEvent(redirectReady);
-      window.lana?.log(
-        'Adobe Analytics done callback failed to trigger, 3 second timeout dispatched event.',
-        { sampleRate: 100, tags: 'DC_Milo,Project Unity (DC)' },
-      );
-    }, 3000);
-    setCookie('UTS_Uploaded', Date.now(), cookieExp);
-    const calcUploadedTime = uploadedTime();
-    const metadata = { ...data, uploadTime: calcUploadedTime, userAttempts };
-    handleAnalyticsEvent('job:uploaded', metadata, false, canSendDataToSplunk);
-    if (LIMITS[VERB]?.multipleFiles) {
-      handleAnalyticsEvent('job:multi-file-uploaded', metadata, false, canSendDataToSplunk);
-    }
-    exitFlag = true;
-    setUser();
-    incrementVerbKey(`${VERB}_attempts`);
-  }
 }


### PR DESCRIPTION
## Description
Introduce a reliable LCP-based analytics loader for browsers without support for LCP observer with fallback and logs to lana. 

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-171714](https://jira.corp.adobe.com/browse/MWPW-171714)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.hlx.page/acrobat/online/compress-pdf
- http://mwpw-171714--dc--adobecom.hlx.page/acrobat/online/compress-pdf