### PR TITLE
MWPW-170394 Handle prerender element

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -495,6 +495,15 @@ export default async function init(element) {
     return;
   }
 
+  // Remove the prerender element when it's in the viewport
+  const observer = new IntersectionObserver(([entry]) => {
+    if (entry.isIntersecting) {
+      document.querySelector('#prerender_verb-widget')?.remove();
+      observer.disconnect();
+    }
+  });
+  observer.observe(element);
+
   const isMobile = isMobileDevice();
   const isTablet = isTabletDevice();
 


### PR DESCRIPTION
## Description

- Remove the prerender element if it exists when the verb widget is displayed.

## Related Issue
Resolves: [MWPW-170394](https://jira.corp.adobe.com/browse/MWPW-170394)

## Test URLs
- http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf
- http://mwpw-170394x--dc--adobecom.aem.page/acrobat/online/compress-pdf