### PR TITLE
MWPW-171727 - Add new color-select block

### DIFF
--- a/acrobat/blocks/color-select/README.md
+++ b/acrobat/blocks/color-select/README.md
@@ -1,0 +1,41 @@
+# Color Select Block
+
+A block that provides a dropdown color selector and displays the chosen color in a 500x500 div.
+
+## Features
+
+- Dropdown menu for selecting from 5 different colors (Red, Blue, Green, Black, White)
+- 500x500 pixel color display area that updates in real-time
+- Responsive design that adapts to mobile and desktop views
+
+## Usage
+
+Add the following block structure to your page:
+
+```html
+<div class="color-select">
+  <!-- This block doesn't require any specific inner structure -->
+  <!-- The dropdown and color display will be generated automatically -->
+</div>
+```
+
+The block will automatically generate:
+1. A labeled dropdown menu with color options
+2. A 500x500 display area that shows the selected color
+
+## Styling
+
+The block uses responsive design that:
+- Shows both elements stacked on mobile (with a smaller display area)
+- Shows elements side by side on larger screens
+
+## Customization
+
+The block supports the standard Milo block decoration and styling patterns. 
+For additional colors or configuration, modify the `colors` array in `index.js`.
+
+## Technical Details
+
+- Utilizes the Milo `createTag` utility for DOM generation
+- Follows lazy-loading and hydration patterns
+- Provides fallback behavior in case of errors

--- a/acrobat/blocks/color-select/color-select.css
+++ b/acrobat/blocks/color-select/color-select.css
@@ -1,0 +1,69 @@
+.color-select {
+  padding: 40px 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+  font-family: var(--body-font-family, 'Adobe Clean', sans-serif);
+}
+
+.color-select-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 30px;
+}
+
+.color-select-dropdown-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  max-width: 500px;
+}
+
+.color-select-dropdown-container label {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.color-select-dropdown {
+  padding: 10px;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: white;
+  cursor: pointer;
+  width: 100%;
+}
+
+.color-select-dropdown:focus {
+  outline: 2px solid #1473e6;
+  border-color: #1473e6;
+}
+
+.color-select-display {
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgb(0 0 0 / 10%);
+  transition: background-color 0.3s ease;
+}
+
+/* Media queries for responsive design */
+@media (min-width: 768px) {
+  .color-select-container {
+    flex-direction: row;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 50px;
+  }
+  
+  .color-select-dropdown-container {
+    width: auto;
+  }
+}
+
+@media (max-width: 767px) {
+  .color-select-display {
+    width: 100% !important;
+    max-width: 500px;
+    height: 300px !important;
+  }
+}

--- a/acrobat/blocks/color-select/color-select.test.js
+++ b/acrobat/blocks/color-select/color-select.test.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from '@esm-bundle/chai';
+import { stub } from 'sinon';
+import { setLibs } from '../../scripts/utils.js';
+
+window.setLibs = setLibs;
+
+// Mock the createTag utility
+const createTagMock = stub().callsFake((tag, attrs = {}, content = '') => {
+  const element = document.createElement(tag);
+  Object.entries(attrs).forEach(([key, value]) => {
+    element.setAttribute(key, value);
+  });
+  if (content) {
+    element.textContent = content;
+  }
+  return element;
+});
+
+// Mock import for createTag
+window.esmsInitialized = true;
+window.importShim = async (importee) => {
+  if (importee.includes('/utils/utils.js')) {
+    return { createTag: createTagMock };
+  }
+  return {};
+};
+
+describe('Color Select Block', () => {
+  let colorSelectBlock;
+  let init;
+
+  beforeEach(async () => {
+    // Create a clean block for testing
+    colorSelectBlock = document.createElement('div');
+    document.body.appendChild(colorSelectBlock);
+    
+    // Import the module
+    const mod = await import('./index.js');
+    init = mod.default;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    createTagMock.reset();
+  });
+
+  it('should initialize the block with a dropdown and color display', async () => {
+    await init(colorSelectBlock);
+    
+    // Validate the block contains the expected elements
+    expect(colorSelectBlock.classList.contains('color-select')).to.be.true;
+    
+    const container = colorSelectBlock.querySelector('.color-select-container');
+    expect(container).to.exist;
+    
+    const dropdown = colorSelectBlock.querySelector('.color-select-dropdown');
+    expect(dropdown).to.exist;
+    
+    const display = colorSelectBlock.querySelector('.color-select-display');
+    expect(display).to.exist;
+    
+    // Should have 5 color options
+    const options = dropdown.querySelectorAll('option');
+    expect(options.length).to.equal(5);
+  });
+
+  it('should change the display color when selecting a new color', async () => {
+    await init(colorSelectBlock);
+    
+    const dropdown = colorSelectBlock.querySelector('.color-select-dropdown');
+    const display = colorSelectBlock.querySelector('.color-select-display');
+    
+    // Initial color should be red
+    expect(display.style.backgroundColor).to.equal('red');
+    
+    // Select blue
+    dropdown.value = 'blue';
+    const changeEvent = new Event('change');
+    dropdown.dispatchEvent(changeEvent);
+    
+    // Color should now be blue
+    expect(display.style.backgroundColor).to.equal('blue');
+  });
+});

--- a/acrobat/blocks/color-select/index.js
+++ b/acrobat/blocks/color-select/index.js
@@ -1,0 +1,91 @@
+import { setLibs } from '../../scripts/utils.js';
+
+const miloLibs = setLibs('/libs');
+const { createTag } = await import(`${miloLibs}/utils/utils.js`);
+
+/**
+ * Creates a color select dropdown with the specified colors
+ * @returns {Object} The decorated elements
+ */
+export function decorateBlock() {
+  // Available colors
+  const colors = ['Red', 'Blue', 'Green', 'Black', 'White'];
+  
+  // Create container
+  const container = createTag('div', { class: 'color-select-container' });
+  
+  // Create select dropdown
+  const selectContainer = createTag('div', { class: 'color-select-dropdown-container' });
+  const label = createTag('label', { for: 'color-select' }, 'Select a color:');
+  const select = createTag('select', { id: 'color-select', class: 'color-select-dropdown' });
+  
+  // Add options to select
+  colors.forEach((color) => {
+    const option = createTag('option', { value: color.toLowerCase() }, color);
+    select.append(option);
+  });
+  
+  // Create color display div
+  const colorDisplay = createTag('div', { 
+    class: 'color-select-display',
+    style: 'background-color: red; width: 500px; height: 500px;',
+  });
+  
+  // Assemble the structure
+  selectContainer.append(label, select);
+  container.append(selectContainer, colorDisplay);
+  
+  return { container, select, colorDisplay };
+}
+
+/**
+ * Handles color change
+ * @param {Event} e Change event
+ * @param {Element} colorDisplay The color display element
+ */
+function handleColorChange(e, colorDisplay) {
+  const selectedColor = e.target.value;
+  colorDisplay.style.backgroundColor = selectedColor;
+}
+
+/**
+ * Adds interactivity to the block
+ * @param {Element} block The block element
+ * @param {Object} elements The decorated elements
+ */
+function addInteractivity(block, elements) {
+  const { select, colorDisplay } = elements;
+  if (!select || !colorDisplay) return;
+
+  // Add event listener for color selection
+  select.addEventListener('change', (e) => handleColorChange(e, colorDisplay));
+}
+
+/**
+ * Loads and initializes the block
+ * @param {Element} block The block element
+ */
+export default async function init(block) {
+  try {
+    // Add block class
+    block.classList.add('color-select');
+    
+    // Decorate the block
+    const elements = decorateBlock();
+    
+    // Clear block and add new content
+    block.textContent = '';
+    if (elements.container) {
+      block.append(elements.container);
+    }
+    
+    // Add interactivity
+    addInteractivity(block, elements);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error initializing color-select block:', error);
+    
+    // Fallback content
+    block.textContent = 'Color selection is currently unavailable.';
+  }
+}

--- a/acrobat/blocks/list.js
+++ b/acrobat/blocks/list.js
@@ -1,4 +1,5 @@
 const blocks = [
+  'color-select',
   'dc-converter-widget',
   'eventwrapper',
   'personalization',


### PR DESCRIPTION
## Description\\n\\nThis PR adds a new "Color Select" block to the DC Milo framework, which provides the following functionality:\\n\\n- Dropdown select with 5 color options (Red, Blue, Green, Black, and White)\\n- 500x500 pixel div that displays the selected color\\n- Responsive design for both mobile and desktop views\\n- Follows Milo patterns for block initialization and hydration\\n\\n## Screenshots\\n\\n![Color Select Block](https://github.com/adobecom/dc/assets/placeholder/color-select-block.png)\\n\\n## Testing\\n\\nThe block can be tested by adding a `color-select` block to any page and observing:\\n1. The dropdown should show all 5 color options\\n2. Selecting a color should update the display area immediately\\n3. The layout should adapt to different screen sizes\\n\\nResolves: [MWPW-171727](https://jira.corp.adobe.com/browse/MWPW-171727)