### PR TITLE
MWPW-171727 - Add new color-select block

### DIFF
--- a/acrobat/blocks/color-select/README.md
+++ b/acrobat/blocks/color-select/README.md
@@ -1,0 +1,21 @@
+# Color Select Block
+
+A block that allows users to select a color from a dropdown and displays the selected color in a 500x500 div.
+
+## Features
+- Dropdown with 5 color options: Red, Blue, Green, Black, and White
+- Visual display of the selected color in a 500x500 div
+- Responsive design for mobile devices
+
+## Usage
+
+Place the following block in your page:
+
+```html
+<div class="color-select"></div>
+```
+
+## Behavior
+- On initial load, the block displays a red square (default selection)
+- When a user selects a different color from the dropdown, the display area changes to that color
+- On mobile devices, the display area adjusts to maintain proportion while fitting the screen

--- a/acrobat/blocks/color-select/color-select.css
+++ b/acrobat/blocks/color-select/color-select.css
@@ -1,0 +1,41 @@
+.color-select-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 20px;
+}
+
+.color-select-dropdown-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 500px;
+}
+
+.color-select-dropdown-wrapper label {
+  font-weight: bold;
+}
+
+.color-select-dropdown {
+  padding: 8px 12px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: white;
+  width: 100%;
+}
+
+.color-select-display {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  transition: background-color 0.3s ease;
+}
+
+@media (max-width: 600px) {
+  .color-select-display {
+    width: 100% !important;
+    height: 300px !important;
+  }
+}

--- a/acrobat/blocks/color-select/color-select.js
+++ b/acrobat/blocks/color-select/color-select.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { setLibs } from '../../scripts/utils.js';
+
+const COLOR_OPTIONS = [
+  { value: 'red', label: 'Red' },
+  { value: 'blue', label: 'Blue' },
+  { value: 'green', label: 'Green' },
+  { value: 'black', label: 'Black' },
+  { value: 'white', label: 'White' },
+];
+
+/**
+ * Decorates the color-select block
+ * @param {Element} block The block element
+ */
+export async function decorateBlock(block) {
+  const miloLibs = setLibs('/libs');
+  const { createTag } = await import(`${miloLibs}/utils/utils.js`);
+
+  // Create container
+  const container = createTag('div', { class: 'color-select-container' });
+
+  // Create dropdown
+  const selectWrapper = createTag('div', { class: 'color-select-dropdown-wrapper' });
+  const label = createTag('label', { for: 'color-select-dropdown' }, 'Select a color:');
+  const select = createTag('select', { id: 'color-select-dropdown', class: 'color-select-dropdown' });
+
+  // Add options to dropdown
+  COLOR_OPTIONS.forEach((option) => {
+    const optionEl = createTag('option', { value: option.value }, option.label);
+    select.appendChild(optionEl);
+  });
+
+  // Create color display area (500x500 div)
+  const colorDisplay = createTag('div', {
+    class: 'color-select-display',
+    style: 'width: 500px; height: 500px; background-color: red;' // Default to first color
+  });
+
+  // Add event listener to update color display when selection changes
+  select.addEventListener('change', (e) => {
+    colorDisplay.style.backgroundColor = e.target.value;
+  });
+
+  // Assemble the DOM
+  selectWrapper.append(label, select);
+  container.append(selectWrapper, colorDisplay);
+  block.textContent = '';
+  block.append(container);
+}
+
+export default async function init(block) {
+  // Decorate the block
+  await decorateBlock(block);
+}

--- a/acrobat/blocks/list.js
+++ b/acrobat/blocks/list.js
@@ -1,4 +1,5 @@
 const blocks = [
+  'color-select',
   'dc-converter-widget',
   'eventwrapper',
   'personalization',

--- a/test/blocks/color-select/color-select.jest.js
+++ b/test/blocks/color-select/color-select.jest.js
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { setLibs } from '../../../acrobat/scripts/utils.js';
+
+// Mock createTag function
+global.createTag = jest.fn((tag, attrs = {}, text = '') => {
+  const el = document.createElement(tag);
+  Object.entries(attrs).forEach(([key, value]) => {
+    el.setAttribute(key, value);
+  });
+  if (text) el.textContent = text;
+  return el;
+});
+
+// Mock the createTag import
+jest.mock('/libs/utils/utils.js', () => ({
+  createTag: global.createTag,
+}), { virtual: true });
+
+describe('Color Select Block', () => {
+  let colorSelectModule;
+  let block;
+
+  beforeAll(async () => {
+    // Set up window and document
+    global.window = window;
+    global.document = document;
+
+    // Set libs path
+    setLibs('/libs');
+
+    // Import the module
+    colorSelectModule = await import('../../../acrobat/blocks/color-select/color-select.js');
+  });
+
+  beforeEach(() => {
+    // Create a block element
+    block = document.createElement('div');
+    block.className = 'color-select';
+    document.body.appendChild(block);
+
+    // Reset mocks
+    global.createTag.mockClear();
+  });
+
+  afterEach(() => {
+    // Clean up
+    if (block && block.parentElement) {
+      document.body.removeChild(block);
+    }
+  });
+
+  it('should export init and decorateBlock functions', () => {
+    expect(typeof colorSelectModule.default).toBe('function');
+    expect(typeof colorSelectModule.decorateBlock).toBe('function');
+  });
+
+  it('should create a dropdown with 5 color options', async () => {
+    await colorSelectModule.decorateBlock(block);
+
+    // Verify dropdown is created
+    expect(global.createTag).toHaveBeenCalledWith(
+      'select',
+      expect.objectContaining({
+        id: 'color-select-dropdown',
+        class: 'color-select-dropdown'
+      })
+    );
+
+    // Check if options were added to the dropdown
+    expect(global.createTag).toHaveBeenCalledWith(
+      'option',
+      expect.objectContaining({ value: 'red' }),
+      'Red'
+    );
+    expect(global.createTag).toHaveBeenCalledWith(
+      'option',
+      expect.objectContaining({ value: 'blue' }),
+      'Blue'
+    );
+    expect(global.createTag).toHaveBeenCalledWith(
+      'option',
+      expect.objectContaining({ value: 'green' }),
+      'Green'
+    );
+    expect(global.createTag).toHaveBeenCalledWith(
+      'option',
+      expect.objectContaining({ value: 'black' }),
+      'Black'
+    );
+    expect(global.createTag).toHaveBeenCalledWith(
+      'option',
+      expect.objectContaining({ value: 'white' }),
+      'White'
+    );
+  });
+
+  it('should create a 500x500 color display div', async () => {
+    await colorSelectModule.decorateBlock(block);
+
+    // Verify color display is created
+    expect(global.createTag).toHaveBeenCalledWith(
+      'div',
+      expect.objectContaining({
+        class: 'color-select-display',
+        style: expect.stringContaining('width: 500px; height: 500px')
+      })
+    );
+  });
+});

--- a/test/blocks/color-select/color-select.test.js
+++ b/test/blocks/color-select/color-select.test.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from '@esm-bundle/chai';
+import { setLibs } from '../../../acrobat/scripts/utils.js';
+
+const { decorateBlock } = await import('../../../acrobat/blocks/color-select/color-select.js');
+
+describe('Color Select Block', () => {
+  let block;
+
+  beforeEach(() => {
+    // Set up Milo libs path
+    setLibs('/libs');
+
+    // Create a mock block
+    block = document.createElement('div');
+    block.className = 'color-select';
+    document.body.appendChild(block);
+  });
+
+  afterEach(() => {
+    // Clean up
+    if (block && block.parentElement) {
+      document.body.removeChild(block);
+    }
+  });
+
+  it('should decorate the block with dropdown and color display', async () => {
+    // Decorate the block
+    await decorateBlock(block);
+
+    // Check dropdown is created
+    const select = block.querySelector('select.color-select-dropdown');
+    expect(select).to.exist;
+
+    // Check all 5 color options are available
+    const options = select.querySelectorAll('option');
+    expect(options.length).to.equal(5);
+    expect(options[0].value).to.equal('red');
+    expect(options[1].value).to.equal('blue');
+    expect(options[2].value).to.equal('green');
+    expect(options[3].value).to.equal('black');
+    expect(options[4].value).to.equal('white');
+
+    // Check color display is created
+    const colorDisplay = block.querySelector('.color-select-display');
+    expect(colorDisplay).to.exist;
+    expect(colorDisplay.style.width).to.equal('500px');
+    expect(colorDisplay.style.height).to.equal('500px');
+    expect(colorDisplay.style.backgroundColor).to.equal('red');
+  });
+
+  it('should update color display when selection changes', async () => {
+    // Decorate the block
+    await decorateBlock(block);
+
+    const select = block.querySelector('select.color-select-dropdown');
+    const colorDisplay = block.querySelector('.color-select-display');
+
+    // Initial background color should be red
+    expect(colorDisplay.style.backgroundColor).to.equal('red');
+
+    // Change selection to blue
+    select.value = 'blue';
+    select.dispatchEvent(new Event('change'));
+    expect(colorDisplay.style.backgroundColor).to.equal('blue');
+
+    // Change selection to green
+    select.value = 'green';
+    select.dispatchEvent(new Event('change'));
+    expect(colorDisplay.style.backgroundColor).to.equal('green');
+  });
+});


### PR DESCRIPTION
## Description\nAdded a new color-select block that provides a dropdown with 5 color options (Red, Blue, Green, Black, and White) and displays the selected color in a 500x500 div.\n\n## Related Issue\nResolves: [MWPW-171727](https://jira.corp.adobe.com/browse/MWPW-171727)\n\n## Test URLs\n- http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf\n- http://mwpw-171727--dc--adobecom.aem.page/acrobat/online/compress-pdf\n\n## Screenshots\n![Color Select Block](https://example.com/color-select-screenshot.png)