### PR TITLE
MWPW-171598 Update the list of prod hosts for RNR

### DIFF
--- a/acrobat/blocks/rnr/rnr.js
+++ b/acrobat/blocks/rnr/rnr.js
@@ -10,11 +10,9 @@ const { createTag } = await import(`${miloLibs}/utils/utils.js`);
 // #region Constants
 
 const isProd = [
-  'main--dc--adobecom.aem.page',
-  'main--dc--adobecom.aem.live',
-  'main--dc--adobecom.hlx.page',
-  'main--dc--adobecom.hlx.live',
   'www.adobe.com',
+  'sign.ing',
+  'edit.ing',
 ].includes(window.location.hostname);
 
 const COMMENTS_MAX_LENGTH = 500;


### PR DESCRIPTION
## Description
Only pages on production hosts can access the RNR production endpoint.

## Related Issue
Resolves: [MWPW-171598](https://jira.corp.adobe.com/browse/MWPW-171598)

## Test URLs
- http://main--dc--adobecom.aem.page/acrobat/online/sign-pdf
- http://mwpw-171598--dc--adobecom.aem.page/acrobat/online/sign-pdf