### PR TITLE
[MWPW-171660] Tab closure event is not logged in splunk

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -431,9 +431,11 @@ function getDemoEndpoint() {
 
 let exitFlag;
 function handleExit(event, verb, userObj, unloadFlag) {
-  if (exitFlag) { return; }
-  window.analytics.verbAnalytics('job:browser-tab-closure', verb, userObj, unloadFlag);
-  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, userObj, getSplunkEndpoint());
+  if (exitFlag) return;
+  const splunkEndpoint = getSplunkEndpoint();
+  const metadata = { ...userObj };
+  window.analytics.verbAnalytics('job:browser-tab-closure', verb, metadata, unloadFlag);
+  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, metadata, splunkEndpoint, true);
   event.preventDefault();
   event.returnValue = true;
 }

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -431,11 +431,9 @@ function getDemoEndpoint() {
 
 let exitFlag;
 function handleExit(event, verb, userObj, unloadFlag) {
-  if (exitFlag) return;
-  const splunkEndpoint = getSplunkEndpoint();
-  const metadata = { ...userObj };
-  window.analytics.verbAnalytics('job:browser-tab-closure', verb, metadata, unloadFlag);
-  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, metadata, splunkEndpoint, true);
+  if (exitFlag) { return; }
+  window.analytics.verbAnalytics('job:browser-tab-closure', verb, userObj, unloadFlag);
+  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, userObj, getSplunkEndpoint(), true);
   event.preventDefault();
   event.returnValue = true;
 }

--- a/acrobat/scripts/alloy/verb-widget.js
+++ b/acrobat/scripts/alloy/verb-widget.js
@@ -108,13 +108,15 @@ function createPayloadForSplunk(metaData) {
   };
 }
 
-export function sendAnalyticsToSplunk(eventName, verb, metaData, splunkEndpoint) {
+export function sendAnalyticsToSplunk(eventName, verb, metaData, splunkEndpoint, sendBeacon = false) {
   try {
     const eventDataPayload = createPayloadForSplunk({ ...metaData, eventName, verb });
+    const payloadString = JSON.stringify(eventDataPayload);
+    if (sendBeacon && navigator.sendBeacon && navigator.sendBeacon(splunkEndpoint, payloadString)) return;
     fetch(splunkEndpoint, {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify(eventDataPayload),
+      headers: { 'Content-Type': 'application/json' },
+      body: payloadString,
     });
   } catch(error) {
     window.lana?.log(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Tab closure event is being handled in code and event is being sent to Adobe Analytics but not to splunk. Send beacon event instead of fetch for tab closure analytics. sendBeacon is async, unlike fetch and hence should be able to send data to analytics during tab close.

<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-171660](https://jira.corp.adobe.com/browse/MWPW-171660)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- hhttps://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-to-word
- https://stage--dc--adobecom.hlx.page/acrobat/online/test/pdf-to-word?unitylibs=tab-closure-beacon