### PR TITLE
MWPW-171965 Fix RNR accessibility

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -3,7 +3,7 @@
   --rnr-tooltip-text-color: #fff;
   --rnr-tooltip-transition-time: 0.3s;
   --rnr-tooltip-z-index: 50;
-  --rnr-comments-textarea-height: 60px;
+  --rnr-comments-textarea-height: 76px;
   --rnr-comments-footer-height: 25px;
   --rnr-fieldset-height: calc(
     var(--rnr-comments-textarea-height) + var(--rnr-comments-footer-height)
@@ -118,6 +118,13 @@
   box-sizing: border-box;
   resize: none;
   overflow: auto;
+}
+
+.rnr-comments-label {
+  font-style: italic;
+  color: var(--color-gray-600);
+  padding: 0 8px;
+  display: block;
 }
 
 .rnr-comments:focus ~ .rnr-comments-footer > .rnr-comments-submit,

--- a/acrobat/blocks/rnr/rnr.js
+++ b/acrobat/blocks/rnr/rnr.js
@@ -357,13 +357,19 @@ function initRatingFielset(fieldset, rnrForm, showComments) {
 }
 
 function initCommentsFieldset(fieldset) {
+  const labelText = window.mph['rnr-comments-placeholder'] || '';
+  const label = createTag('label', {
+    class: 'rnr-comments-label',
+    for: 'rnr-comments-textarea',
+  }, labelText);
+
   const textarea = createTag('textarea', {
+    id: 'rnr-comments-textarea',
     class: 'rnr-comments',
     name: 'comments',
-    'aria-label': window.mph['rnr-comments-label'] || '',
+    'aria-label': labelText,
     cols: 40,
     maxLength: metadata.commentsMaxLength,
-    placeholder: window.mph['rnr-comments-placeholder'] || '',
   });
   if (!metadata.interactive) textarea.setAttribute('disabled', 'disabled');
 
@@ -395,7 +401,7 @@ function initCommentsFieldset(fieldset) {
     else submitTag.setAttribute('disabled', 'disabled');
   });
 
-  fieldset.append(textarea, footerContainer);
+  fieldset.append(label, textarea, footerContainer);
 }
 
 function initSummary(container) {


### PR DESCRIPTION
## Description
Remove the placeholder attribute for the RNR comment field and use a persistent label. 

## Related Issue
Resolves: [MWPW-171965](https://jira.corp.adobe.com/browse/MWPW-171965)
https://www.deque.com/blog/accessible-forms-the-problem-with-placeholders/

## Test URLs
- https://main--dc--adobecom.aem.live/acrobat/online/sign-pdf
- https://mwpw-171965--dc--adobecom.aem.live/acrobat/online/sign-pdf