### PR TITLE
[MWPW-172923] Multiple browser tab closure events are being sent for single upload instance

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -934,7 +934,7 @@ export default async function init(element) {
       handleAnalyticsEvent('job:multi-file-uploading', metadata, false, canSendDataToSplunk);
     }
     setCookie('UTS_Uploading', Date.now(), cookieExp);
-    registerTabCloseEvent({ ...data, userAttempts: attempts });
+    registerTabCloseEvent({ ...data, userAttempts: attempts, workflowStep: 'uploading' });
   }
 
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
@@ -1038,14 +1038,14 @@ export default async function init(element) {
     const analyticsMap = {
       change: () => {
         handleAnalyticsEvent('choose-file:open', metadata, true, canSendDataToSplunk);
-        registerTabCloseEvent(metadata);
+        registerTabCloseEvent({ ...metadata, workflowStep: 'preuploading' });
       },
       drop: () => {
         ['files-dropped', 'entry:clicked', 'discover:clicked'].forEach((analyticsEvent) => {
           handleAnalyticsEvent(analyticsEvent, metadata, true, canSendDataToSplunk);
         });
         setDraggingClass(widget, false);
-        registerTabCloseEvent(metadata);
+        registerTabCloseEvent({ ...metadata, workflowStep: 'preuploading' });
       },
       cancel: () => {
         handleAnalyticsEvent('job:cancel', metadata, true, canSendDataToSplunk);

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -436,6 +436,7 @@ function handleExit(event, verb, userObj, unloadFlag) {
   window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, userObj, getSplunkEndpoint(), true);
   event.preventDefault();
   event.returnValue = true;
+  window.removeEventListener('beforeunload', handleExit);
 }
 
 function isMobileDevice() {
@@ -919,6 +920,12 @@ export default async function init(element) {
     document.cookie = `${name}=${value};domain=.adobe.com;path=/;expires=${expires}`;
   }
 
+  function registerTabCloseEvent(event_data) {
+    window.addEventListener('beforeunload', (windowEvent) => {
+      handleExit(windowEvent, VERB, event_data, false);
+    });
+  }
+
   function handleUploadingEvent(data, attempts, cookieExp, canSendDataToSplunk) {
     prefetchTarget();
     const metadata = mergeData({ ...data, userAttempts: attempts });
@@ -927,9 +934,7 @@ export default async function init(element) {
       handleAnalyticsEvent('job:multi-file-uploading', metadata, false, canSendDataToSplunk);
     }
     setCookie('UTS_Uploading', Date.now(), cookieExp);
-    window.addEventListener('beforeunload', (windowEvent) => {
-      handleExit(windowEvent, VERB, { ...data, userAttempts: attempts }, false);
-    });
+    registerTabCloseEvent({ ...data, userAttempts: attempts });
   }
 
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
@@ -1033,12 +1038,14 @@ export default async function init(element) {
     const analyticsMap = {
       change: () => {
         handleAnalyticsEvent('choose-file:open', metadata, true, canSendDataToSplunk);
+        registerTabCloseEvent(metadata);
       },
       drop: () => {
         ['files-dropped', 'entry:clicked', 'discover:clicked'].forEach((analyticsEvent) => {
           handleAnalyticsEvent(analyticsEvent, metadata, true, canSendDataToSplunk);
         });
         setDraggingClass(widget, false);
+        registerTabCloseEvent(metadata);
       },
       cancel: () => {
         handleAnalyticsEvent('job:cancel', metadata, true, canSendDataToSplunk);

--- a/acrobat/scripts/alloy/verb-widget.js
+++ b/acrobat/scripts/alloy/verb-widget.js
@@ -73,7 +73,7 @@ function eventData(metaData, { appReferrer: referrer, trackingId: tracking }) {
 
 function createPayloadForSplunk(metaData) {
   const {
-    verb, eventName, noOfFiles, uploadTime, name, type, size, count, workflowStep, uploadType, userAttempts, errorData, chunkUploadAttempt, chunkNumber, assetId, maxRetryCount
+    verb, eventName, noOfFiles, uploadTime, type, size, count, workflowStep, uploadType, userAttempts, errorData, chunkUploadAttempt, chunkNumber, assetId, maxRetryCount
   } = metaData;
 
   return {
@@ -84,7 +84,7 @@ function createPayloadForSplunk(metaData) {
       ...(uploadTime && { uploadTime }),
       ...(uploadType && { uploadType })
     },
-    content: { name, type, size, count, fileType: type, totalSize: size,
+    content: { type, size, count, fileType: type, totalSize: size,
       ...(workflowStep && { workflowStep }),
       ...(noOfFiles && { no_of_files: noOfFiles }),
       ...(chunkUploadAttempt && { chunkUploadAttempt }),


### PR DESCRIPTION
## Description
remove the "beforeunload" listener once we have handled it after tab close. Also added handleExit for events before uploading

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-172923](https://jira.corp.adobe.com/browse/MWPW-172923)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf
- https://rosahu-mwpw-172923--dc--adobecom.aem.page/acrobat/online/compress-pdf 