### PR TITLE
[MWPW-172923] Multiple browser tab closure events are being sent for single upload instance

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -430,12 +430,13 @@ function getDemoEndpoint() {
 }
 
 let exitFlag;
-let tabClosureSent, isUploading;
+let tabClosureSent;
+let isUploading;
 function handleExit(event, verb, userObj, unloadFlag, workflowStep) {
   if (exitFlag || tabClosureSent || (isUploading && workflowStep === 'preuploading')) { return; }
   tabClosureSent = true;
   window.analytics.verbAnalytics('job:browser-tab-closure', verb, userObj, unloadFlag);
-  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, {...userObj, workflowStep }, getSplunkEndpoint(), true);
+  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, { ...userObj, workflowStep }, getSplunkEndpoint(), true);
   event.preventDefault();
   event.returnValue = true;
 }
@@ -921,9 +922,9 @@ export default async function init(element) {
     document.cookie = `${name}=${value};domain=.adobe.com;path=/;expires=${expires}`;
   }
 
-  function registerTabCloseEvent(event_data, workflowStep) {
+  function registerTabCloseEvent(eventData, workflowStep) {
     window.addEventListener('beforeunload', (windowEvent) => {
-      handleExit(windowEvent, VERB, event_data, false, workflowStep);
+      handleExit(windowEvent, VERB, eventData, false, workflowStep);
     });
   }
 
@@ -1059,8 +1060,8 @@ export default async function init(element) {
         handleAnalyticsEvent('job:redirect-success', metadata, false, canSendDataToSplunk);
       },
       chunk_uploaded: () => {
-        if (canSendDataToSplunk)  window.analytics.sendAnalyticsToSplunk('job:chunk-uploaded', VERB, metadata, getSplunkEndpoint());
-      }
+        if (canSendDataToSplunk) window.analytics.sendAnalyticsToSplunk('job:chunk-uploaded', VERB, metadata, getSplunkEndpoint());
+      },
     };
 
     if (analyticsMap[event]) {

--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -430,13 +430,14 @@ function getDemoEndpoint() {
 }
 
 let exitFlag;
-function handleExit(event, verb, userObj, unloadFlag) {
-  if (exitFlag) { return; }
+let tabClosureSent, isUploading;
+function handleExit(event, verb, userObj, unloadFlag, workflowStep) {
+  if (exitFlag || tabClosureSent || (isUploading && workflowStep === 'preuploading')) { return; }
+  tabClosureSent = true;
   window.analytics.verbAnalytics('job:browser-tab-closure', verb, userObj, unloadFlag);
-  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, userObj, getSplunkEndpoint(), true);
+  window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, {...userObj, workflowStep }, getSplunkEndpoint(), true);
   event.preventDefault();
   event.returnValue = true;
-  window.removeEventListener('beforeunload', handleExit);
 }
 
 function isMobileDevice() {
@@ -920,13 +921,14 @@ export default async function init(element) {
     document.cookie = `${name}=${value};domain=.adobe.com;path=/;expires=${expires}`;
   }
 
-  function registerTabCloseEvent(event_data) {
+  function registerTabCloseEvent(event_data, workflowStep) {
     window.addEventListener('beforeunload', (windowEvent) => {
-      handleExit(windowEvent, VERB, event_data, false);
+      handleExit(windowEvent, VERB, event_data, false, workflowStep);
     });
   }
 
   function handleUploadingEvent(data, attempts, cookieExp, canSendDataToSplunk) {
+    isUploading = true;
     prefetchTarget();
     const metadata = mergeData({ ...data, userAttempts: attempts });
     handleAnalyticsEvent('job:uploading', metadata, false, canSendDataToSplunk);
@@ -934,7 +936,7 @@ export default async function init(element) {
       handleAnalyticsEvent('job:multi-file-uploading', metadata, false, canSendDataToSplunk);
     }
     setCookie('UTS_Uploading', Date.now(), cookieExp);
-    registerTabCloseEvent({ ...data, userAttempts: attempts, workflowStep: 'uploading' });
+    registerTabCloseEvent(metadata, 'uploading');
   }
 
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
@@ -1038,14 +1040,14 @@ export default async function init(element) {
     const analyticsMap = {
       change: () => {
         handleAnalyticsEvent('choose-file:open', metadata, true, canSendDataToSplunk);
-        registerTabCloseEvent({ ...metadata, workflowStep: 'preuploading' });
+        registerTabCloseEvent(metadata, 'preuploading');
       },
       drop: () => {
         ['files-dropped', 'entry:clicked', 'discover:clicked'].forEach((analyticsEvent) => {
           handleAnalyticsEvent(analyticsEvent, metadata, true, canSendDataToSplunk);
         });
         setDraggingClass(widget, false);
-        registerTabCloseEvent({ ...metadata, workflowStep: 'preuploading' });
+        registerTabCloseEvent(metadata, 'preuploading');
       },
       cancel: () => {
         handleAnalyticsEvent('job:cancel', metadata, true, canSendDataToSplunk);


### PR DESCRIPTION
## Description
Preuploading tab closure events were also being logged on tab closure. I have added couple of flags to ensure tab closure events are sent only once for an asset upload. Also, if the tab was closed during file upload, preuploading should not be sent as tab closure

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-172923](https://jira.corp.adobe.com/browse/MWPW-172923)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf
- https://rosahu-mwpw-172923-2--dc--adobecom.aem.page/acrobat/online/compress-pdf