### PR TITLE
Do not show exit dialog on page unload if file upload is not happening

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -437,6 +437,7 @@ function handleExit(event, verb, userObj, unloadFlag, workflowStep) {
   tabClosureSent = true;
   window.analytics.verbAnalytics('job:browser-tab-closure', verb, userObj, unloadFlag);
   window.analytics.sendAnalyticsToSplunk('job:browser-tab-closure', verb, { ...userObj, workflowStep }, getSplunkEndpoint(), true);
+  if (!isUploading) return;
   event.preventDefault();
   event.returnValue = true;
 }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
"leave site" confirmation prompt display in splash screen for multi file/non pdf file upload in compress for logged out user in stage.
For MFU, signed out, uploading and uploaded events are not sent. The 'beforeunload' event gets registered during file drop/chose and hence when the redirection happens, the browser leave dialog is shown. 

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-173128](https://jira.corp.adobe.com/browse/MWPW-173128)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf
- http://mwpw-XXXXXX--dc--adobecom.aem.page/acrobat/online/compress-pdf