### PR TITLE
MWPW-172124: Displaying the info icon on safari browsers

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.css
+++ b/acrobat/blocks/verb-widget/verb-widget.css
@@ -56,7 +56,7 @@
   --verb-wrapper-padding-y: var(--consonant-spacing-s);
   --verb-wrapper-padding-x: var(--consonant-spacing-s);
   --verb-wrapper-border-width: 3px;
-  --verb-info-icon-margin: 0 10px 0 4px;
+  --verb-info-icon-margin: 8px 10px 0 4px;
   --verb-info-icon-size-width: 18px;
   --verb-info-icon-size-height: 18px;
   --verb-cta-margin-bottom: var(--consonant-spacing-s);
@@ -183,9 +183,13 @@
 
 .info-icon {
   display: flex;
+  margin: var(--verb-info-icon-margin);
+}
+
+.info-icon svg {
+  display: block;
   width: var(--verb-info-icon-size-width);
   height: var(--verb-info-icon-size-height);
-  margin: var(--verb-info-icon-margin);
 }
 
 .verb-footer {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Fix the position and size 

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-172124](https://jira.corp.adobe.com/browse/MWPW-172124)

## Test URLs
<!-- List the URLs where the changes can be tested -->
http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf
http://main--dc--adobecom.aem.page/acrobat/online/sign-pdf
http://main--dc--adobecom.aem.page/acrobat/online/add-pdf-page-numbers
http://mwpw-172124--dc--adobecom.aem.page/acrobat/online/compress-pdf
http://mwpw-172124--dc--adobecom.aem.page/acrobat/online/sign-pdf
http://mwpw-172124--dc--adobecom.aem.page/acrobat/online/add-pdf-page-numbers