### PR TITLE
Chunk upload failure events are missing from splunk logging

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -1120,6 +1120,7 @@ export default async function init(element) {
       error_max_quota_exceeded: 'error:max_quota_exceeded',
       error_no_storage_provision: 'error:no_storage_provision',
       error_duplicate_asset: 'error:duplicate_asset',
+      warn_chunk_upload: 'warn:verb_upload_warn_chunk_upload',
     };
 
     const key = Object.keys(errorAnalyticsMap).find((k) => errorCode?.includes(k));


### PR DESCRIPTION
## Description
chunk upload event was not being logged since event type has been changed from generic to warn chunk failure. Needed this update in slytherin error map as well
Injection PR: https://github.com/adobecom/unity/pull/389/files 

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-XXXXXX](https://jira.corp.adobe.com/browse/MWPW-XXXXXX)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- http://main--dc--adobecom.aem.page/acrobat/online/compress-pdf
- http://mwpw-XXXXXX--dc--adobecom.aem.page/acrobat/online/compress-pdf