### PR TITLE
MWPW-173558: Verb widget consonant dropzoone max width

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.css
+++ b/acrobat/blocks/verb-widget/verb-widget.css
@@ -90,6 +90,8 @@
   --padding-total-height: calc(var(--consonant-spacing-m) + (var(--consonant-spacing-s) * 2));
   --total-height: calc(100vh - (var(--header-height) + var(--padding-total-height) + var(--border-total-height)));
   --verb-wrapper-min-height: calc(100vh - (var(--header-height) + var(--padding-total-height) + var(--border-total-height)));
+  --verb-wrapper-width: 1008px;
+  --verb-wrapper-max-width: calc(var(--verb-wrapper-width) - ((var(--verb-wrapper-padding-x) * 2) + var(--verb-wrapper-border-width) * 2));
 
   @media screen and (min-width: 768px) {
     --verb-widget-min-height: 360px;
@@ -119,6 +121,10 @@
 
     /* Heading type XXL */
     --consonant-heading-xxl-size: 44px;
+  }
+
+  @media screen and (min-width: 1392px) {
+    --verb-wrapper-width: 1200px;
   }
 
 }
@@ -241,7 +247,7 @@
 }
 
 .verb-wrapper {
-  max-width: calc(1008px - ((var(--verb-wrapper-padding-x) * 2) + var(--verb-wrapper-border-width) * 2));
+  max-width: var(--verb-wrapper-max-width);
   padding: var(--verb-wrapper-padding-y) var(--verb-wrapper-padding-x);
   border: var(--verb-wrapper-border-width) dashed var(--consonant-color-gray-300);
   border-radius: var(--consonant-radius-xl);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Widget wrapper min-width  to 1200 when bigger screens

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-173558](https://jira.corp.adobe.com/browse/MWPW-173558)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-173558--dc--adobecom.aem.live/acrobat/online/compress-pdf