### PR TITLE
MWPW-173559 Fix imports with a dot path

### DIFF
--- a/edgeworkers/Acrobat_DC_web_prod/main.js
+++ b/edgeworkers/Acrobat_DC_web_prod/main.js
@@ -124,7 +124,12 @@ export async function responseProvider(request) {
     // Change relative paths to absolute. Remove JS-driven CSP in favor of HTTP header.
     let inlineScript = scripts
       .replace('await import(\'./contentSecurityPolicy/csp.js\')', '{default:()=>{}}')
-      .replace('await import(\'./dcLana.js\')', 'await import(\'/acrobat/scripts/dcLana.js\')');
+      .replace('await import(\'./dcLana.js\')', 'await import(\'/acrobat/scripts/dcLana.js\')')
+      .replace('await import(\'./susiAuthHandler.js\')', 'await import(\'/acrobat/scripts/susiAuthHandler.js\')')
+      .replace('await import(\'./geo-phoneNumber.js\')', 'await import(\'/acrobat/scripts/geo-phoneNumber.js\')')
+      .replace('await import(\'./threeInOne.js\')', 'await import(\'/acrobat/scripts/threeInOne.js\')')
+      .replace('await import(\'./tooltips.js\')', 'await import(\'/acrobat/scripts/tooltips.js\')')
+      .replace('await import(\'./imageReplacer.js\')', 'await import(\'/acrobat/scripts/imageReplacer.js\')');
 
     if (!(mobileWidget && request.device.isMobile) && !unityWorkflow) {
       inlineScript = dcConverter


### PR DESCRIPTION
## Description
When scripts.js is embedded into an HTML, those dot paths should be updated.

## Related Issue
Resolves: [MWPW-173559](https://jira.corp.adobe.com/browse/MWPW-173559)

## Test URLs
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-173559--dc--adobecom.aem.live/acrobat/online/compress-pdf