### PR TITLE
MWPW-164769 Use role alert for thank you message

### DIFF
--- a/acrobat/blocks/rnr/rnr.js
+++ b/acrobat/blocks/rnr/rnr.js
@@ -497,7 +497,7 @@ function initControls(element) {
   const summaryContainer = createTag('div', { class: 'rnr-summary-container ' });
   const thankYou = createTag(
     'div',
-    { class: 'rnr-thank-you', 'aria-live': 'assertive' },
+    { class: 'rnr-thank-you', role: 'alert' },
     window.mph['rnr-thank-you-label'] || '',
   );
 


### PR DESCRIPTION
## Description
The attribute `aria-live` doesn't work as expected. Setting the focus and/or adding `aria-relevant` didn't help. Use `role` instead. 

## Related Issue
Resolves: [MWPW-164769](https://jira.corp.adobe.com/browse/MWPW-164769)

## Test URLs
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-164769--dc--adobecom.aem.live/acrobat/online/compress-pdf