### PR TITLE
[MWPW-173837] intermittently "leave site" confirmation prompt display in splash screen

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -1022,6 +1022,7 @@ export default async function init(element) {
   }
 
   function handleUploadedEvent(data, attempts, cookieExp, canSendDataToSplunk) {
+    exitFlag = true;
     setTimeout(() => {
       window.dispatchEvent(redirectReady);
       window.lana?.log(
@@ -1036,7 +1037,6 @@ export default async function init(element) {
     if (LIMITS[VERB]?.multipleFiles) {
       handleAnalyticsEvent('job:multi-file-uploaded', metadata, false, canSendDataToSplunk);
     }
-    exitFlag = true;
     setUser();
     incrementVerbKey(`${VERB}_attempts`);
   }


### PR DESCRIPTION
## Description
set exitFlag as true before redirect event being sent to unity. 
Due to the race condition, intermittently, if redirection begins before the exit flag has been set to true,  the "beforeunload" listener gets invoked. Since the exitFlag is not yet set to true, we see the browser closure confirmation dialogue.

Also, this could be non injection and on prod as well.

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-173837](https://jira.corp.adobe.com/browse/MWPW-173837)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-XXXXXX--dc--adobecom.aem.live/acrobat/online/compress-pdf