### PR TITLE
MWPW-174233

### DIFF
--- a/acrobat/blocks/prompt-card/prompt-card.js
+++ b/acrobat/blocks/prompt-card/prompt-card.js
@@ -62,7 +62,7 @@ function createBlock(el, cfg, a11yActionUpdate) {
   const copy = createTag('div', { class: 'prompt-copy' }, cfg.prompt);
   const prompt = createTag('input', { id: 'prompt', value: cfg.prompt });
   const wrapper = createTag('div', { class: 'prompt-copy-btn-wrapper' });
-  const copyBtn = createTag('span', { class: 'prompt-copy-btn', role: 'button', tabindex: 0, 'aria-label': `Copy ${cfg.prompt}` }, cfg.button);
+  const copyBtn = createTag('span', { class: 'prompt-copy-btn', role: 'button', tabindex: 0, 'aria-label': `${cfg.button} ${cfg.prompt}` }, cfg.button);
   wrapper.append(copyBtn);
   prefix.appendChild(icon);
   prefix.appendChild(createTag('span', null, cfg.prefix));


### PR DESCRIPTION
## Description
Removing the hardcoded `Copy` from the `aria-label` and replacing w/ the placeholder (`cfg.button`)
## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-174233](https://jira.corp.adobe.com/browse/MWPW-174233)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-174233--dc--adobecom.aem.live/acrobat/online/compress-pdf