### PR TITLE
MWPW-174474

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -58,6 +58,7 @@ export const LIMITS = {
     maxNumFiles: 1,
     multipleFiles: false,
     mobileApp: true,
+    typeOneLanding: true,
   },
   'number-pages': {
     maxFileSize: 104857600, // 100 MB
@@ -219,6 +220,7 @@ export const LIMITS = {
       'text/plain',
     ],
     multipleFiles: true,
+    typeOneLanding: true,
   },
   'delete-pages': {
     maxFileSize: 104857600, // 100 MB
@@ -985,7 +987,7 @@ export default async function init(element) {
       button.accept = [...LIMITS[VERB].acceptedFiles, ...LIMITS[VERB].signedInAcceptedFiles];
     }
 
-    if (accountType !== 'type1') redDir(VERB);
+    if (accountType !== 'type1' && LIMITS[VERB].typeOneLanding) redDir(VERB);
   }
 
   function handleAnalyticsEvent(


### PR DESCRIPTION
## Description
Added new var to keep certain verbs on the Frictionless pages for type1 users
```
if (accountType !== 'type1') redDir(VERB);
if (accountType = 'type1' && !LIMITS[VERB].typeOneLanding) redDir(VERB);
```

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-174474](https://jira.corp.adobe.com/browse/MWPW-174474)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-174474--dc--adobecom.aem.live/acrobat/online/compress-pdf