### PR TITLE
MWPW-175206

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -621,7 +621,7 @@ export default async function init(element) {
   const children = element.querySelectorAll(':scope > div');
   const VERB = element.classList[1];
   const widgetHeading = createTag('h1', { class: 'verb-heading' }, children[0].textContent);
-  if (children.length > 2 ) {
+  if (children.length > 2) {
     widgetSubHeading = createTag('p', { class: 'verb-copy' }, children[1].textContent);
     widgetMobSubHeading = createTag('p', { class: 'verb-copy' }, children[2].textContent);
   }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Adding the ability to override the subheading in the `verb-widget` block

- https://github.com/adobecom/dc/pull/1242
## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-175206](https://jira.corp.adobe.com/browse/MWPW-175206)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-175206--dc--adobecom.aem.live/acrobat/online/compress-pdf