### PR TITLE
MWPW-176078 Fix Dependabot security alerts: upgrade dawidd6/action-download-artifact from v2 to v6

### DIFF
--- a/.github/workflows/metadata-published.yml
+++ b/.github/workflows/metadata-published.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Download artifact
       if: ${{ startsWith(github.event.client_payload.path, '/metadata') }}
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v6
       with:
         workflow: metadata-published.yml
         workflow_conclusion: success

--- a/.github/workflows/page-published.yml
+++ b/.github/workflows/page-published.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: page-published.yml
           workflow_conclusion: success


### PR DESCRIPTION
## Summary
This PR fixes the Dependabot security alerts by upgrading the vulnerable `dawidd6/action-download-artifact` action from v2 to v6 in both workflow files.

## Changes Made
- Updated `.github/workflows/page-published.yml` to use `dawidd6/action-download-artifact@v6`
- Updated `.github/workflows/metadata-published.yml` to use `dawidd6/action-download-artifact@v6`

## Security Fix
The v6 version resolves the vulnerability where repository forks were searched by default, which could be exploited to introduce compromised artifacts. The newer version changes the default behavior to avoid searching forks for matching artifacts.

## Related Issue
Resolves MWPW-176078

## Testing
- [x] Verified the action version is updated in both workflow files
- [x] Confirmed the syntax is correct for the new version

## Security Alerts Fixed
- https://github.com/adobecom/dc/security/dependabot/30
- https://github.com/adobecom/dc/security/dependabot/31