### PR TITLE
MWPW-176062: Update NodeJS version from 18 to 20/22

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
 
     permissions:
       contents: write
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
 
     permissions:
       contents: write

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/tools/cspUpdate/cspUpdate.js
+++ b/tools/cspUpdate/cspUpdate.js
@@ -10,8 +10,8 @@ const URL_PULL = `https://api.github.com/repos/${OWNER}/${REPO}/pulls`;
 const FILES = ['dev.js', 'stage.js', 'prod.js']
 const nodeVersion = process.version.split('.')[0].replace('v', '');
 
-if(nodeVersion < 18){
-  console.log("Please use Node version 18 or newer");
+if(nodeVersion < 20){
+  console.log("Please use Node version 20 or newer");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
Updates NodeJS version across the DC repository to address the end-of-life of NodeJS 18 (April 30, 2025).

## Changes Made
- **GitHub Actions Workflows**: Updated to use NodeJS 22.x
  - `.github/workflows/run-tests.yml`
  - `.github/workflows/run-lint.yml`
- **CSP Update Tool**: Updated to require NodeJS 20 or newer
  - `tools/cspUpdate/cspUpdate.js`

## Context
NodeJS 18 has reached end-of-life on April 30, 2025. This update ensures the repository continues to use supported NodeJS versions for both CI/CD workflows and development tools.

## Testing
- [ ] GitHub Actions workflows run successfully with NodeJS 22.x
- [ ] CSP update tool works with NodeJS 20+

Fixes: MWPW-176062