### PR TITLE
MWPW-177168 Hide sticky CTA for mobile and tablet

### DIFF
--- a/acrobat/blocks/verb-widget/verb-widget.js
+++ b/acrobat/blocks/verb-widget/verb-widget.js
@@ -1096,6 +1096,10 @@ export default async function init(element) {
 
       labelElement.innerHTML = verbCtaClone.innerHTML;
       link.closest('div').append(labelElement);
+      const notification = link.closest('.notification');
+      if (notification && (isMobile || isTablet)) {
+        notification.style.display = 'none';
+      }
       link.remove();
       labelElement.addEventListener('click', (data) => {
         soloClicked = true;


### PR DESCRIPTION
## Description
Override the mobile and tablet style of the notification block for a sticky CTA.

## Related Issue
Resolves: [MWPW-177168](https://jira.corp.adobe.com/browse/MWPW-177168)

## Test URLs
- https://main--dc--adobecom.aem.page/drafts/steenmeyer/acrobat/online/pdf-editor-fixed
- https://mwpw-177168--dc--adobecom.aem.page/drafts/steenmeyer/acrobat/online/pdf-editor-fixed