### PR TITLE
[OPT-33911] Add download and benefits folder to htmlExclude

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -343,6 +343,8 @@ const CONFIG = {
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?learn(\/.*)?/,
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?benefits(\/.*)?/,
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?download(\/.*)?/,
   ],
   imsScope: 'AdobeID,openid,gnav,pps.read,firefly_api,additional_info.roles,read_organizations,account_cluster.read',
 };


### PR DESCRIPTION
## Description
Add download and benefits folder to htmlExclude

## Related Issue
Resolves: [OPT-33911](https://jira.corp.adobe.com/browse/OPT-33911)

## Test URLs
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://add-exclusions--dc--adobecom.aem.live/acrobat/online/compress-pdf