### PR TITLE
MWPW-185573 remove unused references to dc widget and include acrobat adobe.com in prod check

### DIFF
--- a/edgeworkers/Acrobat_DC_web_prod/main.js
+++ b/edgeworkers/Acrobat_DC_web_prod/main.js
@@ -6,18 +6,14 @@ import { createResponse } from 'create-response';
 import { httpRequest } from 'http-request';
 //import { logger } from 'log';
 import { EdgeKV } from './edgekv.js';
-import localeMap from './utils/locales.js';
-import verbMap from './utils/verbs.js';
 import contentSecurityPolicy from './utils/csp/index.js';
 
 export async function responseProvider(request) {
   const path = request.path.split('/');
   const first = path[1];
-  const locale = localeMap[first];
   const last = path.splice(-1)[0].split('.')[0];
-  const verb = verbMap[last] || last;
   const origin = `${request.scheme}://${request.host}`;
-  const isProd = request.host === 'www.adobe.com';
+  const isProd = request.host === 'www.adobe.com' || request.host === 'acrobat.adobe.com';
   const rewriter = new HtmlRewritingStream();
 
   const fetchFrictionlessPage = async () => {
@@ -35,16 +31,10 @@ export async function responseProvider(request) {
       throw err;
     }
 
-    // Make preliminary pass through the content to capture version metadata
+    // Make preliminary pass through the content to capture metadata
     const firstPassRewriter = new HtmlRewritingStream();
-    let version, widgetVersion, mobileWidget, unityWorkflow;
+    let mobileWidget, unityWorkflow;
     const prefix = isProd ? '' : 'stg-';
-    firstPassRewriter.onElement(`meta[name="${prefix}dc-widget-version"]`, el => {
-      widgetVersion = el.getAttribute('content');
-    });
-    firstPassRewriter.onElement(`meta[name="${prefix}dc-generate-cache-version"]`, el => {
-      version = el.getAttribute('content');
-    });
     firstPassRewriter.onElement('meta[name="mobile-widget"]', el => {
       mobileWidget = el.getAttribute('content');
     });
@@ -80,7 +70,7 @@ export async function responseProvider(request) {
       delete responseHeaders[prop];
     }
 
-    return [responseStream, responseHeaders, version, widgetVersion, mobileWidget, unityWorkflow];
+    return [responseStream, responseHeaders, mobileWidget, unityWorkflow];
   };
 
   const fetchResource = async path => {
@@ -89,31 +79,6 @@ export async function responseProvider(request) {
       return response.text();
     }
     throw new Error(`Failed to fetch resource: ${path} status: ${response.status}`);
-  };
-
-  const fetchFrictionlessPageAndInlineSnippet = async () => {
-    const [responseStream, responseHeaders, version, widgetVersion, mobileWidget, unityWorkflow] = await fetchFrictionlessPage();
-
-    if (!verb || !locale || !version || !widgetVersion) {
-      throw new Error('Missing metadata');
-    }
-
-    if (!(mobileWidget && request.device.isMobile) && !unityWorkflow) {
-      const snippet =
-        await fetchResource(`/dc/dc-generate-cache/dc-hosted-${version}/${verb}-${locale}.html`);
-      const snippetHead = snippet.substring(snippet.indexOf('<head>')+6, snippet.indexOf('</head>'));
-      const snippetBody = snippet.substring(snippet.indexOf('<body>')+6, snippet.indexOf('</body>'));
-
-      rewriter.onElement('head', el => {
-        el.append(snippetHead);
-      });
-      rewriter.onElement('div.dc-converter-widget', el => {
-        el.append(`<section id="edge-snippet">${snippetBody}</section>`);
-      });
-    }
-    const dcCoreVersion = widgetVersion.split("_")[0];
-
-    return [responseStream, responseHeaders, dcCoreVersion, mobileWidget, unityWorkflow];
   };
 
   const scriptHashes = [];
@@ -193,14 +158,14 @@ export async function responseProvider(request) {
 
   try {
     const [
-      [responseStream, responseHeaders, dcCoreVersion, mobileWidget, unityWorkflow],
+      [responseStream, responseHeaders, mobileWidget, unityWorkflow],
       scripts,
       dcConverter,
       dcStyles,
       miloStyles,
       verbWidgetStyles
     ] = await Promise.all([
-      fetchFrictionlessPageAndInlineSnippet(),
+      fetchFrictionlessPage(),
       fetchResource('/acrobat/scripts/scripts.js'),
       fetchResource('/acrobat/blocks/dc-converter-widget/dc-converter-widget.js'),
       fetchResource('/acrobat/styles/styles.css'),
@@ -212,8 +177,6 @@ export async function responseProvider(request) {
     inlineStyles(dcStyles, miloStyles, verbWidgetStyles, unityWorkflow, prerenderTop);
 
     const csp = contentSecurityPolicy(isProd, scriptHashes);
-    const acrobat = isProd ? 'https://acrobat.adobe.com' : 'https://stage.acrobat.adobe.com';
-    const pdfnow = isProd ? 'https://pdfnow.adobe.io' : 'https://pdfnow-stage.adobe.io';
     const adobeid = isProd ? 'https://adobeid-na1.services.adobe.com' : 'https://adobeid-na1-stg1.services.adobe.com';
 
     let headerLink = [
@@ -232,13 +195,6 @@ export async function responseProvider(request) {
         `</libs/utils/utils.js>;rel="preload";as="script";crossorigin="anonymous"`,
         `</libs/features/placeholders.js>;rel="preload";as="script";crossorigin="anonymous"`,
         `<${first === 'acrobat' ? '' : `/${first}`}/dc-shared/placeholders.json>;rel="preload";as="fetch";crossorigin="anonymous"`,
-      ];
-    } else if (!(mobileWidget && request.device.isMobile)) {
-      headerLink = [...headerLink,
-        `<${acrobat}>;rel="preconnect"`,
-        `<${pdfnow}>;rel="preconnect"`,
-        `<${acrobat}/dc-core/${dcCoreVersion}/dc-core.js>;rel="preload";as="script"`,
-        `<${acrobat}/dc-core/${dcCoreVersion}/dc-core.css>;rel="preload";as="style"`,
       ];
     }
     headerLink = headerLink.join();


### PR DESCRIPTION
is `unityWorkflow` always true now?  Can we reduce this code further?

replaces adobecom/dc#1320
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issue
<!-- Link to the JIRA ticket or GitHub issue that this PR resolves -->
Resolves: [MWPW-XXXXXX](https://jira.corp.adobe.com/browse/MWPW-XXXXXX)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-XXXXXX--dc--adobecom.aem.live/acrobat/online/compress-pdf