### PR TITLE
MWPW-192736: validate milolibs/unitylibs branch params to prevent DOM…

### DIFF
--- a/acrobat/blocks/unity/unity.js
+++ b/acrobat/blocks/unity/unity.js
@@ -98,6 +98,7 @@ function getUnityLibs(prodLibs = '/unitylibs') {
   if (!/\.hlx\.|\.aem\.|local|stage/.test(hostname)) return prodLibs;
   // eslint-disable-next-line compat/compat
   const branch = new URLSearchParams(search).get('unitylibs') || 'main';
+  if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
   if (branch === 'main' && hostname === 'www.stage.adobe.com') return prodLibs;
   const env = hostname.includes('.aem.') ? 'aem' : 'hlx';
   return `https://${branch}${branch.includes('--') ? '' : '--unity--adobecom'}.${env}.live/unitylibs`;

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -26,6 +26,7 @@ const setLibs = (prodLibs, location = window.location) => {
   if (!/\.hlx\.|\.aem\.|local|stage/.test(hostname)) return prodLibs;
   // eslint-disable-next-line compat/compat
   const branch = new URLSearchParams(search).get('milolibs') || 'main';
+  if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
   if (branch === 'main' && hostname === 'www.stage.adobe.com') return '/libs';
   if (branch === 'local') return 'http://localhost:6456/libs';
   return `https://${branch}${branch.includes('--') ? '' : '--milo--adobecom'}.aem.live/libs`;

--- a/acrobat/scripts/utils.js
+++ b/acrobat/scripts/utils.js
@@ -28,6 +28,7 @@ export const [setLibs, getLibs] = (() => {
         if (!/\.hlx\.|\.aem\.|local|stage/.test(hostname)) return prodLibs;
         // eslint-disable-next-line compat/compat
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
+        if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
         if (branch === 'main' && hostname === 'www.stage.adobe.com') return '/libs';
         if (branch === 'local') return 'http://localhost:6456/libs';
         return `https://${branch}${branch.includes('--') ? '' : '--milo--adobecom'}.aem.live/libs`;

--- a/head.html
+++ b/head.html
@@ -9,6 +9,7 @@
     const { hostname, search } = location;
     if (!/\.hlx\.|\.aem\.|local|stage/.test(hostname)) return prodLibs;
     const branch = new URLSearchParams(search).get('milolibs') || 'main';
+    if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
     if (branch === 'main' && hostname === 'www.stage.adobe.com') return '/libs';
     if (branch === 'local') return 'http://localhost:6456/libs';
     const env = hostname.includes('.hlx.') ? 'hlx' : 'aem';
@@ -19,6 +20,7 @@
     const { hostname, search } = window.location;
     if (!/\.hlx\.|\.aem\.|local|stage/.test(hostname)) return prodLibs;
     const branch = new URLSearchParams(search).get('unitylibs') || 'main';
+    if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
     if (branch === 'main' && hostname === 'www.stage.adobe.com') return prodLibs;
     const env = hostname.includes('.hlx.') ? 'hlx' : 'aem';
     return `https://${branch}${branch.includes('--')? '' : '--unity--adobecom'}.${env}.live/unitylibs`;


### PR DESCRIPTION
… XSS (#1325)

The milolibs and unitylibs query params were interpolated directly into template literals used for dynamic import()s, letting an attacker point module loading at an arbitrary origin and execute JS in the page context.

Add a strict whitelist (^[a-zA-Z0-9_-]+$) and throw on invalid input in head.html, acrobat/scripts/utils.js, acrobat/scripts/scripts.js, and acrobat/blocks/unity/unity.js.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issue
Resolves: [MWPW-192736](https://jira.corp.adobe.com/browse/MWPW-192736)

## Test URLs
<!-- List the URLs where the changes can be tested -->
- https://main--dc--adobecom.aem.live/acrobat/online/compress-pdf
- https://mwpw-XXXXXX--dc--adobecom.aem.live/acrobat/online/compress-pdf